### PR TITLE
Cache server method reponses, test configuration and caching

### DIFF
--- a/services/api/index.js
+++ b/services/api/index.js
@@ -1,7 +1,8 @@
 exports.register = function api(server, options, next) {
   server.register([
       require('./lib/postgre'),
-      require('./lib/utils')
+      require('./lib/utils'),
+      require('./lib/invalidate')
     ], function(err) {
     if ( err ) {
       return next(err);

--- a/services/api/lib/invalidate.js
+++ b/services/api/lib/invalidate.js
@@ -1,0 +1,87 @@
+var _ = require('lodash');
+
+var ROUTES = {
+  '/users/{user}/projects/{project}': {
+    methods: ['patch', 'delete'],
+    group: 'projects',
+    invalidate: [{
+      func: 'findOne',
+      args: function(request) {
+        return request.paramsArray.reverse();
+      }
+    }]
+  },
+  '/users/{user}/projects/{project}/feature': {
+    methods: ['patch'],
+    group: 'projects',
+    invalidate: [{
+      funcName: 'findOne',
+      args: function(request) {
+        return request.paramsArray.reverse();
+      }
+    }]
+  },
+  '/users/{user}/projects/{project}/pages/{page}': {
+    methods: ['patch', 'delete'],
+    group: 'pages',
+    invalidate: [{
+      funcName: 'findOne',
+      args: function(request) {
+        return request.paramsArray.slice(1);
+      }
+    }, {
+      funcName: 'findAll',
+      args: function(request) {
+        return [request.params.project];
+      }
+    }]
+  },
+  '/users/{user}/projects/{project}/pages/{page}/elements/{element}': {
+    methods: ['patch', 'delete'],
+    group: 'elements',
+    invalidate: [{
+      funcName: 'findOne',
+      args: function(request) {
+        return request.paramsArray.slice(2).reverse();
+      }
+    }, {
+      funcName: 'findAll',
+      args: function(request) {
+        return [request.params.page];
+      }
+    }]
+  }
+};
+
+exports.register = function(server, options, done) {
+  server.on('response', function(request, event, tags) {
+    if ( request.response.statusCode !== 200 ) {
+      return;
+    }
+
+    var route = ROUTES[request.route.path];
+    if ( !route ) {
+      return;
+    }
+
+    var method = _.find(route.methods, request.route.method);
+    if ( !method ) {
+      return;
+    }
+
+    route.invalidate.forEach(function(invalidate) {
+      server.methods[route.group][invalidate.funcName]
+        .cache.drop(invalidate.args(request), function(err) {
+        if ( err ) {
+          server.log('error', err);
+        }
+      });
+    });
+  });
+  done();
+};
+
+exports.register.attributes = {
+  name: 'webmaker-cache-invalidator',
+  version: '1.0.0'
+};

--- a/services/api/lib/postgre.js
+++ b/services/api/lib/postgre.js
@@ -60,11 +60,7 @@ exports.register = function(server, options, done) {
 
   var cachedMethods = {
     projects: [
-      'findAll',
-      'findUsersProjects',
-      'findOne',
-      'findRemixes',
-      'findFeatured'
+      'findOne'
     ],
     pages: [
       'findAll',
@@ -84,6 +80,10 @@ exports.register = function(server, options, done) {
       'remove'
     ],
     projects: [
+      'findFeatured',
+      'findAll',
+      'findUsersProjects',
+      'findRemixes',
       'create',
       'update',
       'feature',

--- a/services/api/lib/postgre.js
+++ b/services/api/lib/postgre.js
@@ -106,7 +106,6 @@ exports.register = function(server, options, done) {
 
   // expose so tests can stub
   server.expose('pg', pg);
-  server.expose('executeQuery', executeQuery);
 
   done();
 };

--- a/services/api/routes/public.js
+++ b/services/api/routes/public.js
@@ -27,8 +27,8 @@ var routes = [
       validate: {
         payload: {
           username: Joi.string().required(),
-          language: Joi.string().length(2).optional(),
-          country: Joi.string().length(2).optional()
+          language: Joi.string().length(2).default('en'),
+          country: Joi.string().length(2).default('US')
         }
       },
       cors: {

--- a/services/api/routes/public.js
+++ b/services/api/routes/public.js
@@ -27,8 +27,8 @@ var routes = [
       validate: {
         payload: {
           username: Joi.string().required(),
-          language: Joi.string().length(2).default('en'),
-          country: Joi.string().length(2).default('US')
+          language: Joi.string().length(2).optional(),
+          country: Joi.string().length(2).optional()
         }
       },
       cors: {

--- a/test/mocks/server.js
+++ b/test/mocks/server.js
@@ -8,9 +8,13 @@ function mockTokenValidator(token, callback) {
   callback(null, !!t, t);
 }
 
-module.exports = function(done) {
+module.exports = function(done, opts) {
   var server = new Hapi.Server();
   server.connection();
+
+  if ( opts && opts.enableCache ) {
+    process.env.DISABLE_CACHE = false;
+  }
 
   server.register(require('hapi-auth-bearer-token'), function(err) {
     if ( err ) {

--- a/test/services/api/methods/cache.js
+++ b/test/services/api/methods/cache.js
@@ -1,0 +1,175 @@
+var Lab = require('lab'),
+  lab = exports.lab = Lab.script(),
+  experiment = lab.experiment,
+  before = lab.before,
+  after = lab.after,
+  test = lab.test,
+  expect = require('code').expect,
+  server;
+
+before(function(done) {
+  require('../../../mocks/server')(function(obj) {
+    server = obj;
+    done();
+  }, { enableCache: true });
+});
+
+after(function(done) {
+  server.stop(done);
+});
+
+experiment('Server Methods', function() {
+  experiment('Has Cache config', function() {
+    test('projects.findAll should have cache config', function(done) {
+      expect(server.methods.projects.findAll).to.be.a.function();
+      expect(server.methods.projects.findAll.cache).to.be.an.object();
+      done();
+    });
+
+    test('projects.findUsersProjects should have cache config', function(done) {
+      expect(server.methods.projects.findUsersProjects).to.be.a.function();
+      expect(server.methods.projects.findUsersProjects.cache).to.be.an.object();
+      done();
+    });
+
+    test('projects.findOne should have cache config', function(done) {
+      expect(server.methods.projects.findOne).to.be.a.function();
+      expect(server.methods.projects.findOne.cache).to.be.an.object();
+      done();
+    });
+
+    test('projects.findRemixes should have cache config', function(done) {
+      expect(server.methods.projects.findRemixes).to.be.a.function();
+      expect(server.methods.projects.findRemixes.cache).to.be.an.object();
+      done();
+    });
+
+    test('projects.findFeatured should have cache config', function(done) {
+      expect(server.methods.projects.findFeatured).to.be.a.function();
+      expect(server.methods.projects.findFeatured.cache).to.be.an.object();
+      done();
+    });
+
+    test('pages.findAll should have cache config', function(done) {
+      expect(server.methods.pages.findAll).to.be.a.function();
+      expect(server.methods.pages.findAll.cache).to.be.an.object();
+      done();
+    });
+
+    test('pages.findOne should have cache config', function(done) {
+      expect(server.methods.pages.findOne).to.be.a.function();
+      expect(server.methods.pages.findOne.cache).to.be.an.object();
+      done();
+    });
+
+    test('elements.findAll should have cache config', function(done) {
+      expect(server.methods.elements.findAll).to.be.a.function();
+      expect(server.methods.elements.findAll.cache).to.be.an.object();
+      done();
+    });
+
+    test('elements.findOne should have cache config', function(done) {
+      expect(server.methods.elements.findOne).to.be.a.function();
+      expect(server.methods.elements.findOne.cache).to.be.an.object();
+      done();
+    });
+  });
+
+  experiment('Has no caching', function() {
+    test('users.find should not have cache config', function(done) {
+      expect(server.methods.users.find).to.be.a.function();
+      expect(server.methods.users.find.cache).to.be.undefined();
+      done();
+    });
+
+    test('users.create should not have cache config', function(done) {
+      expect(server.methods.users.create).to.be.a.function();
+      expect(server.methods.users.create.cache).to.be.undefined();
+      done();
+    });
+
+    test('users.update should not have cache config', function(done) {
+      expect(server.methods.users.update).to.be.a.function();
+      expect(server.methods.users.update.cache).to.be.undefined();
+      done();
+    });
+
+    test('users.remove should not have cache config', function(done) {
+      expect(server.methods.users.remove).to.be.a.function();
+      expect(server.methods.users.remove.cache).to.be.undefined();
+      done();
+    });
+
+    test('projects.create should not have cache config', function(done) {
+      expect(server.methods.projects.create).to.be.a.function();
+      expect(server.methods.projects.create.cache).to.be.undefined();
+      done();
+    });
+
+    test('projects.update should not have cache config', function(done) {
+      expect(server.methods.projects.update).to.be.a.function();
+      expect(server.methods.projects.update.cache).to.be.undefined();
+      done();
+    });
+
+    test('projects.remove should not have cache config', function(done) {
+      expect(server.methods.projects.remove).to.be.a.function();
+      expect(server.methods.projects.remove.cache).to.be.undefined();
+      done();
+    });
+
+    test('pages.create should not have cache config', function(done) {
+      expect(server.methods.pages.create).to.be.a.function();
+      expect(server.methods.pages.create.cache).to.be.undefined();
+      done();
+    });
+
+    test('pages.update should not have cache config', function(done) {
+      expect(server.methods.pages.update).to.be.a.function();
+      expect(server.methods.pages.update.cache).to.be.undefined();
+      done();
+    });
+
+    test('pages.remove should not have cache config', function(done) {
+      expect(server.methods.pages.remove).to.be.a.function();
+      expect(server.methods.pages.remove.cache).to.be.undefined();
+      done();
+    });
+
+    test('elements.create should not have cache config', function(done) {
+      expect(server.methods.elements.create).to.be.a.function();
+      expect(server.methods.elements.create.cache).to.be.undefined();
+      done();
+    });
+
+    test('elements.update should not have cache config', function(done) {
+      expect(server.methods.elements.update).to.be.a.function();
+      expect(server.methods.elements.update.cache).to.be.undefined();
+      done();
+    });
+
+    test('elements.remove should not have cache config', function(done) {
+      expect(server.methods.elements.remove).to.be.a.function();
+      expect(server.methods.elements.remove.cache).to.be.undefined();
+      done();
+    });
+  });
+
+  experiment('generateKeys', function() {
+    test('executes', function(done) {
+      server.methods.projects.findOne([7, 1], function(err, result) {
+        expect(err).to.be.null();
+        server.methods.projects.update(['blah','{}', 7], function(err) {
+          expect(err).to.be.null();
+          server.methods.projects.findOne([7, 1], function(err, result) {
+            expect(err).to.be.null();
+            expect(result.rows.length).to.equal(1);
+            expect(result.rows[0].title).to.equal('test_project_7');
+            expect(result.rows[0].thumbnail).to.deep.equal({});
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/services/api/methods/cache.js
+++ b/test/services/api/methods/cache.js
@@ -20,33 +20,9 @@ after(function(done) {
 
 experiment('Server Methods', function() {
   experiment('Has Cache config', function() {
-    test('projects.findAll should have cache config', function(done) {
-      expect(server.methods.projects.findAll).to.be.a.function();
-      expect(server.methods.projects.findAll.cache).to.be.an.object();
-      done();
-    });
-
-    test('projects.findUsersProjects should have cache config', function(done) {
-      expect(server.methods.projects.findUsersProjects).to.be.a.function();
-      expect(server.methods.projects.findUsersProjects.cache).to.be.an.object();
-      done();
-    });
-
     test('projects.findOne should have cache config', function(done) {
       expect(server.methods.projects.findOne).to.be.a.function();
       expect(server.methods.projects.findOne.cache).to.be.an.object();
-      done();
-    });
-
-    test('projects.findRemixes should have cache config', function(done) {
-      expect(server.methods.projects.findRemixes).to.be.a.function();
-      expect(server.methods.projects.findRemixes.cache).to.be.an.object();
-      done();
-    });
-
-    test('projects.findFeatured should have cache config', function(done) {
-      expect(server.methods.projects.findFeatured).to.be.a.function();
-      expect(server.methods.projects.findFeatured.cache).to.be.an.object();
       done();
     });
 
@@ -76,6 +52,30 @@ experiment('Server Methods', function() {
   });
 
   experiment('Has no caching', function() {
+    test('projects.findRemixes should not have cache config', function(done) {
+      expect(server.methods.projects.findRemixes).to.be.a.function();
+      expect(server.methods.projects.findRemixes.cache).to.be.undefined();
+      done();
+    });
+
+    test('projects.findFeatured should not have cache config', function(done) {
+      expect(server.methods.projects.findFeatured).to.be.a.function();
+      expect(server.methods.projects.findFeatured.cache).to.be.undefined();
+      done();
+    });
+
+    test('projects.findAll should not have cache config', function(done) {
+      expect(server.methods.projects.findAll).to.be.a.function();
+      expect(server.methods.projects.findAll.cache).to.be.undefined();
+      done();
+    });
+
+    test('projects.findUsersProjects should not have cache config', function(done) {
+      expect(server.methods.projects.findUsersProjects).to.be.a.function();
+      expect(server.methods.projects.findUsersProjects.cache).to.be.undefined();
+      done();
+    });
+
     test('users.find should not have cache config', function(done) {
       expect(server.methods.users.find).to.be.a.function();
       expect(server.methods.users.find.cache).to.be.undefined();

--- a/tests.env
+++ b/tests.env
@@ -1,2 +1,4 @@
 export API_VERSION=test
+export DISABLE_CACHE=true
 export POSTGRE_CONNECTION_STRING=postgresql://localhost:5432/webmaker_testing
+export REDIS_URL= redis://localhost:6379


### PR DESCRIPTION
Fixes #37

This patch refactors the webmaker-postgre-adapter plugin and includes caching for all 'find' queries.

responses are cached for 60 seconds, and go stale in 30 seconds. if a stale cache is hit, it tries to refresh it, but if it takes longer than 100 ms it returns the cached version and updates the cached value in the background. 

we can totally tweak the cache numbers