### PR TITLE
Use uppercase for HTTP methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 addons:
   postgresql: "9.4"
 before_script:
- - psql -c 'create database webmaker_testing' -U postgres
+ - npm run inittest -- -U postgres
 after_script:
  - npm run test:reportcoverage
 env: POSTGRE_CONNECTION_STRING='postgres://postgres@localhost:5432/webmaker_testing'

--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ You can view documentation by navigating to `http://localhost:2015/docs` in your
 ## Test
 
 The tests require access to a postgreSQL database named `webmaker_testing`.
-Create it by running the command `createdb webmaker_testing`, the test script will automatically create tables and populate them with data.
+Create it by running the command `npm run inittest`, the test script will automatically create tables and populate them with data.
 
 Run the tests with `npm test`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:createtables": "node scripts/create-tables",
     "test:insertdata": "node scripts/test-data",
     "test:reportcoverage": "npm run test:setup && lab -r lcov | ./node_modules/.bin/coveralls",
+    "inittest": "psql -c 'create database webmaker_testing'",
     "lint": "npm run jshint && npm run jscs",
     "jshint": "jshint -c node_modules/mofo-style/linters/.jshintrc adapters lib services test server.js",
     "jscs": "jscs -c node_modules/mofo-style/linters/.jscsrc adapters lib services test server.js"

--- a/services/api/routes/authenticated.js
+++ b/services/api/routes/authenticated.js
@@ -24,7 +24,7 @@ var numericSchema = Joi.alternatives().try(
 var routes = [
   {
     path: '/users/{user}',
-    method: 'get',
+    method: 'GET',
     handler: users.get,
     config: {
       auth: {
@@ -36,12 +36,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['options', 'get', 'patch', 'delete']
+        methods: ['OPTIONS', 'GET', 'PATCH', 'DELETE']
       }
     }
   }, {
     path: '/users/{user}',
-    method: 'patch',
+    method: 'PATCH',
     handler: users.patch,
     config: {
       auth: {
@@ -58,12 +58,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['options', 'get', 'patch', 'delete']
+        methods: ['OPTIONS', 'GET', 'PATCH', 'DELETE']
       }
     }
   }, {
     path: '/users/{user}',
-    method: 'delete',
+    method: 'DELETE',
     handler: users.del,
     config: {
       auth: {
@@ -75,19 +75,19 @@ var routes = [
         }
       },
       cors: {
-        methods: ['options', 'get', 'patch', 'delete']
+        methods: ['OPTIONS', 'GET', 'PATCH', 'DELETE']
       }
     }
   }, {
     path: '/users/{user}',
-    method: 'options',
+    method: 'OPTIONS',
     handler: users.options,
     config: {
       auth: {
         scope: 'user'
       },
       cors: {
-        methods: ['options', 'get', 'patch', 'delete']
+        methods: ['OPTIONS', 'GET', 'PATCH', 'DELETE']
       },
       plugins: {
         lout: false
@@ -95,7 +95,7 @@ var routes = [
     }
   }, {
     path: '/users/{user}/projects',
-    method: 'post',
+    method: 'POST',
     handler: projects.post.create,
     config: {
       auth: {
@@ -119,12 +119,12 @@ var routes = [
         prerequisites.canCreate
       ],
       cors: {
-        methods: ['options', 'post', 'get']
+        methods: ['OPTIONS', 'POST', 'GET']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}',
-    method: 'patch',
+    method: 'PATCH',
     handler: projects.patch.update,
     config: {
       auth: {
@@ -149,12 +149,12 @@ var routes = [
         prerequisites.canWrite
       ],
       cors: {
-        methods: ['options', 'get', 'patch', 'delete']
+        methods: ['OPTIONS', 'GET', 'PATCH', 'DELETE']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}',
-    method: 'delete',
+    method: 'DELETE',
     handler: projects.del,
     config: {
       auth: {
@@ -172,12 +172,12 @@ var routes = [
         prerequisites.canDelete
       ],
       cors: {
-        methods: ['options', 'get', 'patch', 'delete']
+        methods: ['OPTIONS', 'GET', 'PATCH', 'DELETE']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/remixes',
-    method: 'post',
+    method: 'POST',
     handler: projects.post.remix,
     config: {
       auth: {
@@ -194,12 +194,12 @@ var routes = [
         prerequisites.getProject
       ],
       cors: {
-        methods: ['options', 'get', 'post']
+        methods: ['OPTIONS', 'GET', 'POST']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/feature',
-    method: 'patch',
+    method: 'PATCH',
     handler: projects.patch.feature,
     config: {
       auth: {
@@ -217,12 +217,12 @@ var routes = [
         prerequisites.isMod
       ],
       cors: {
-        methods: ['options', 'post']
+        methods: ['OPTIONS', 'POST']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/feature',
-    method: 'options',
+    method: 'OPTIONS',
     handler: projects.options,
     config: {
       auth: {
@@ -235,12 +235,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['options', 'post']
+        methods: ['OPTIONS', 'POST']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages',
-    method: 'post',
+    method: 'POST',
     handler: pages.post.create,
     config: {
       auth: {
@@ -263,12 +263,12 @@ var routes = [
         prerequisites.canWrite
       ],
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}',
-    method: 'patch',
+    method: 'PATCH',
     handler: pages.patch.update,
     config: {
       auth: {
@@ -293,13 +293,13 @@ var routes = [
         prerequisites.canWrite
       ],
       cors: {
-        methods: ['get', 'patch', 'delete', 'options']
+        methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
   },
   {
     path: '/users/{user}/projects/{project}/pages/{page}',
-    method: 'delete',
+    method: 'DELETE',
     handler: pages.del,
     config: {
       auth: {
@@ -319,12 +319,12 @@ var routes = [
         prerequisites.canDelete
       ],
       cors: {
-        methods: ['get', 'patch', 'delete', 'options']
+        methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}/elements',
-    method: 'post',
+    method: 'POST',
     handler: elements.post,
     config: {
       auth: {
@@ -349,12 +349,12 @@ var routes = [
         prerequisites.canWrite
       ],
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}/elements/{element}',
-    method: 'patch',
+    method: 'PATCH',
     handler: elements.patch.update,
     config: {
       auth: {
@@ -380,12 +380,12 @@ var routes = [
         prerequisites.canWrite
       ],
       cors: {
-        methods: ['get', 'patch', 'delete', 'options']
+        methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}/elements/{element}',
-    method: 'delete',
+    method: 'DELETE',
     handler: elements.del,
     config: {
       auth: {
@@ -407,7 +407,7 @@ var routes = [
         prerequisites.canDelete
       ],
       cors: {
-        methods: ['get', 'patch', 'delete', 'options']
+        methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
   }

--- a/services/api/routes/public.js
+++ b/services/api/routes/public.js
@@ -21,7 +21,7 @@ var numericSchema = Joi.alternatives().try(
 var routes = [
   {
     path: '/users',
-    method: 'post',
+    method: 'POST',
     handler: users.post,
     config: {
       validate: {
@@ -32,17 +32,17 @@ var routes = [
         }
       },
       cors: {
-        methods: ['post', 'options']
+        methods: ['POST', 'OPTIONS']
       },
       description: 'Create a user account'
     }
   }, {
     path: '/users',
-    method: 'options',
+    method: 'OPTIONS',
     handler: users.options,
     config: {
       cors: {
-        methods: ['post', 'options']
+        methods: ['POST', 'OPTIONS']
       },
       plugins: {
         lout: false
@@ -50,7 +50,7 @@ var routes = [
     }
   }, {
     path: '/projects',
-    method: 'get',
+    method: 'GET',
     handler: projects.get.all,
     config: {
       validate: {
@@ -63,12 +63,12 @@ var routes = [
         prerequisites.calculateOffset
       ],
       cors: {
-        methods: ['get', 'options']
+        methods: ['GET', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects',
-    method: 'get',
+    method: 'GET',
     handler: projects.get.allByUser,
     config: {
       validate: {
@@ -85,12 +85,12 @@ var routes = [
         prerequisites.calculateOffset
       ],
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}',
-    method: 'get',
+    method: 'GET',
     handler: projects.get.one,
     config: {
       validate: {
@@ -103,12 +103,12 @@ var routes = [
         prerequisites.getUser
       ],
       cors: {
-        methods: ['get', 'patch', 'options', 'delete']
+        methods: ['GET', 'PATCH', 'OPTIONS', 'DELETE']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}',
-    method: 'options',
+    method: 'OPTIONS',
     handler: projects.options,
     config: {
       validate: {
@@ -118,12 +118,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['get', 'patch', 'options', 'delete']
+        methods: ['GET', 'PATCH', 'OPTIONS', 'DELETE']
       }
     }
   }, {
     path: '/users/{user}/projects',
-    method: 'options',
+    method: 'OPTIONS',
     handler: projects.options,
     config: {
       validate: {
@@ -136,12 +136,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['get', 'options']
+        methods: ['GET', 'OPTIONS']
       }
     }
   }, {
     path: '/projects',
-    method: 'options',
+    method: 'OPTIONS',
     handler: projects.options,
     config: {
       validate: {
@@ -151,12 +151,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['get', 'options']
+        methods: ['GET', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/remixes',
-    method: 'get',
+    method: 'GET',
     handler: projects.get.remixes,
     config: {
       validate: {
@@ -175,12 +175,12 @@ var routes = [
         prerequisites.calculateOffset
       ],
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/discover',
-    method: 'get',
+    method: 'GET',
     handler: projects.get.featured,
     config: {
       validate: {
@@ -193,21 +193,21 @@ var routes = [
         prerequisites.calculateOffset
       ],
       cors: {
-        methods: ['get', 'options']
+        methods: ['GET', 'OPTIONS']
       }
     }
   }, {
     path: '/discover',
-    method: 'options',
+    method: 'OPTIONS',
     handler: projects.options,
     config: {
       cors: {
-        methods: ['get', 'options']
+        methods: ['GET', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/remixes',
-    method: 'options',
+    method: 'OPTIONS',
     handler: projects.options,
     config: {
       validate: {
@@ -217,12 +217,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages',
-    method: 'get',
+    method: 'GET',
     handler: pages.get.all,
     config: {
       validate: {
@@ -236,12 +236,12 @@ var routes = [
         prerequisites.getProject
       ],
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages',
-    method: 'options',
+    method: 'OPTIONS',
     handler: pages.options,
     config: {
       validate: {
@@ -251,12 +251,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}',
-    method: 'get',
+    method: 'GET',
     handler: pages.get.one,
     config: {
       validate: {
@@ -271,12 +271,12 @@ var routes = [
         prerequisites.getProject
       ],
       cors: {
-        methods: ['get', 'patch', 'delete', 'options']
+        methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}',
-    method: 'options',
+    method: 'OPTIONS',
     handler: pages.options,
     config: {
       validate: {
@@ -287,12 +287,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['get', 'patch', 'delete', 'options']
+        methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}/elements',
-    method: 'get',
+    method: 'GET',
     handler: elements.get.all,
     config: {
       validate: {
@@ -308,12 +308,12 @@ var routes = [
         prerequisites.getPage
       ],
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}/elements',
-    method: 'options',
+    method: 'OPTIONS',
     handler: elements.options,
     config: {
       validate: {
@@ -324,12 +324,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['get', 'post', 'options']
+        methods: ['GET', 'POST', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}/elements/{element}',
-    method: 'get',
+    method: 'GET',
     handler: elements.get.one,
     config: {
       validate: {
@@ -346,12 +346,12 @@ var routes = [
         prerequisites.getPage
       ],
       cors: {
-        methods: ['get', 'patch', 'delete', 'options']
+        methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
   }, {
     path: '/users/{user}/projects/{project}/pages/{page}/elements/{element}',
-    method: 'options',
+    method: 'OPTIONS',
     handler: elements.options,
     config: {
       validate: {
@@ -363,12 +363,12 @@ var routes = [
         }
       },
       cors: {
-        methods: ['get', 'patch', 'delete', 'options']
+        methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
   }, {
     path: '/docs/css/style.css',
-    method: 'get',
+    method: 'GET',
     handler: {
       file: './node_modules/lout/public/css/style.css'
     },
@@ -380,7 +380,7 @@ var routes = [
     }
   }, {
     path: '/',
-    method: 'get',
+    method: 'GET',
     handler: function(request, reply) {
       reply.redirect('/docs');
     },

--- a/test/fixtures/configs/element-handlers.js
+++ b/test/fixtures/configs/element-handlers.js
@@ -13,7 +13,7 @@ var moderatorToken = {
 exports.prerequisites = {
   fail: {
     url: '/users/1/projects/1/pages/1/elements/1',
-    method: 'patch',
+    method: 'PATCH',
     payload: {
       styles: {}
     },
@@ -26,11 +26,11 @@ exports.get = {
     success: {
       manyElements:{
         url: '/users/1/projects/1/pages/1/elements',
-        method: 'get'
+        method: 'GET'
       },
       noElements: {
         url: '/users/1/projects/1/pages/2/elements',
-        method: 'get'
+        method: 'GET'
       }
     },
     fail: {
@@ -38,149 +38,149 @@ exports.get = {
         user: {
           notFound: {
             url: '/users/99/projects/3/pages/1/elements',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/cade/projects/1/pages/1/elements',
-            method: 'get'
+            method: 'GET'
           },
           notInteger: {
             url: '/users/1.5/projects/1/pages/1/elements',
-            method: 'get'
+            method: 'GET'
           },
           doesNotOwnProject: {
             url: '/users/1/projects/4/pages/1/elements',
-            method: 'get'
+            method: 'GET'
           }
         },
         project: {
           notFound: {
             url: '/users/1/projects/89/pages/1/elements',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects/coolproject/pages/1/elements',
-            method: 'get'
+            method: 'GET'
           },
           notInteger: {
             url: '/users/1/projects/1.5/pages/1/elements',
-            method: 'get'
+            method: 'GET'
           },
           pageNotInProject: {
             url: '/users/1/projects/1/pages/1/elements',
-            method: 'get'
+            method: 'GET'
           }
         },
         page: {
           notFound: {
             url: '/users/1/projects/1/pages/87/elements',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects/1/pages/foo/elements',
-            method: 'get'
+            method: 'GET'
           },
           notInteger: {
             url: '/users/1/projects/1/pages/1.5/elements',
-            method: 'get'
+            method: 'GET'
           }
         }
       },
       error: {
         url: '/users/1/projects/1/pages/1/elements',
-        method: 'get'
+        method: 'GET'
       }
     }
   },
   one: {
     success: {
       url: '/users/1/projects/1/pages/1/elements/1',
-      method: 'get'
+      method: 'GET'
     },
     fail: {
       params: {
         user: {
           notFound: {
             url: '/users/99/projects/3/pages/1/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           notNumber: {
             url: '/users/cade/projects/1/pages/1/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           notInteger: {
             url: '/users/1.5/projects/1/pages/1/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           doesNotOwnProject: {
             url: '/users/1/projects/4/pages/1/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           }
         },
         project: {
           notFound: {
             url: '/users/1/projects/89/pages/1/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           notNumber: {
             url: '/users/1/projects/coolproject/pages/1/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           notInteger: {
             url: '/users/1/projects/1.5/pages/1/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           pageNotInProject: {
             url: '/users/1/projects/1/pages/1/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           }
         },
         page: {
           notFound: {
             url: '/users/1/projects/1/pages/87/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           notNumber: {
             url: '/users/1/projects/1/pages/foo/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           notInteger: {
             url: '/users/1/projects/1/pages/1.5/elements/1',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           }
         },
         element: {
           notFound: {
             url: '/users/1/projects/1/pages/1/elements/909',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           notNumber: {
             url: '/users/1/projects/1/pages/1/elements/foo',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           },
           notInteger: {
             url: '/users/1/projects/1/pages/1/elements/1.5',
-            method: 'get',
+            method: 'GET',
             headers: userToken
           }
         }
       },
       error: {
         url: '/users/1/projects/1/pages/1/elements/1',
-        method: 'get'
+        method: 'GET'
       }
     }
   }
@@ -190,7 +190,7 @@ exports.create = {
   success: {
     emptyJSON: {
       url: '/users/1/projects/7/pages/6/elements',
-      method: 'post',
+      method: 'POST',
       headers: userToken,
       payload: {
         type: 'text'
@@ -198,7 +198,7 @@ exports.create = {
     },
     withStyle: {
       url: '/users/1/projects/7/pages/6/elements',
-      method: 'post',
+      method: 'POST',
       headers: userToken,
       payload: {
         type: 'text',
@@ -209,7 +209,7 @@ exports.create = {
     },
     withAttributes: {
       url: '/users/1/projects/7/pages/6/elements',
-      method: 'post',
+      method: 'POST',
       headers: userToken,
       payload: {
         type: 'text',
@@ -224,25 +224,25 @@ exports.create = {
       user: {
         notFound: {
           url: '/users/99/projects/3/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         },
         notNumber: {
           url: '/users/cade/projects/1/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         },
         notInteger: {
           url: '/users/1.5/projects/1/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         },
         doesNotOwnProject: {
           url: '/users/1/projects/4/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         }
@@ -250,25 +250,25 @@ exports.create = {
       project: {
         notFound: {
           url: '/users/1/projects/89/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         },
         notNumber: {
           url: '/users/1/projects/coolproject/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         },
         notInteger: {
           url: '/users/1/projects/1.5/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         },
         pageNotInProject: {
           url: '/users/1/projects/1/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         }
@@ -276,19 +276,19 @@ exports.create = {
       page: {
         notFound: {
           url: '/users/1/projects/1/pages/87/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         },
         notNumber: {
           url: '/users/1/projects/1/pages/foo/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         },
         notInteger: {
           url: '/users/1/projects/1/pages/1.5/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: { type: 'text' }
         }
@@ -298,13 +298,13 @@ exports.create = {
       type: {
         notProvided: {
           url: '/users/1/projects/1/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {}
         },
         notString: {
           url: '/users/1/projects/1/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             type: 1
@@ -314,7 +314,7 @@ exports.create = {
       attributes: {
         notObject: {
           url: '/users/1/projects/1/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             type: 'text',
@@ -325,7 +325,7 @@ exports.create = {
       styles: {
         notObject: {
           url: '/users/1/projects/1/pages/1/elements',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             type: 'text',
@@ -336,7 +336,7 @@ exports.create = {
     },
     error: {
       url: '/users/1/projects/1/pages/1/elements',
-      method: 'post',
+      method: 'POST',
       headers: userToken,
       payload: {
         type: 'fail'
@@ -349,7 +349,7 @@ exports.patch = {
   success: {
     onlyStyles: {
       url: '/users/1/projects/1/pages/1/elements/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         styles: {
@@ -359,7 +359,7 @@ exports.patch = {
     },
     onlyAttributes: {
       url: '/users/1/projects/1/pages/1/elements/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         attributes: {
@@ -369,7 +369,7 @@ exports.patch = {
     },
     all: {
       url: '/users/1/projects/1/pages/1/elements/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         styles: {
@@ -386,25 +386,25 @@ exports.patch = {
       user: {
         notFound: {
           url: '/users/75/projects/1/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notNumber: {
           url: '/users/cade/projects/1/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notInteger: {
           url: '/users/1.5/projects/1/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         doesNotOwnProject: {
           url: '/users/1/projects/4/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         }
@@ -412,25 +412,25 @@ exports.patch = {
       project: {
         notFound: {
           url: '/users/1/projects/75/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notNumber: {
           url: '/users/1/projects/foo/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notInteger: {
           url: '/users/1/projects/1.5/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         pageNotInProject: {
           url: '/users/1/projects/1/pages/7/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         }
@@ -438,25 +438,25 @@ exports.patch = {
       page: {
         notFound: {
           url: '/users/1/projects/1/pages/87/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notNumber: {
           url: '/users/1/projects/1/pages/foo/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notInteger: {
           url: '/users/1/projects/1/pages/1.5/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         elementNotInPage: {
           url: '/users/1/projects/1/pages/1/elements/8',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         }
@@ -464,19 +464,19 @@ exports.patch = {
       element: {
         notFound: {
           url: '/users/1/projects/1/pages/1/elements/43',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notNumber: {
           url: '/users/1/projects/1/pages/1/elements/foo',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notInteger: {
           url: '/users/1/projects/1/pages/1/elements/1.5',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         }
@@ -486,7 +486,7 @@ exports.patch = {
       attributes: {
         notObject: {
           url: '/users/1/projects/1/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: {
             attributes: 'foo'
@@ -496,7 +496,7 @@ exports.patch = {
       styles: {
         notObject: {
           url: '/users/1/projects/1/pages/1/elements/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: {
             styles: 'foo'
@@ -505,14 +505,14 @@ exports.patch = {
       },
       missingAll: {
         url: '/users/1/projects/1/pages/1/elements/1',
-        method: 'patch',
+        method: 'PATCH',
         headers: userToken,
         payload: {}
       }
     },
     error: {
       url: '/users/1/projects/1/pages/1/elements/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         attributes: {}
@@ -525,12 +525,12 @@ exports.del = {
   success: {
     owner: {
       url: '/users/2/projects/3/pages/7/elements/8',
-      method: 'delete',
+      method: 'DELETE',
       headers: userToken2
     },
     moderator: {
       url: '/users/2/projects/3/pages/7/elements/9',
-      method: 'delete',
+      method: 'DELETE',
       headers: moderatorToken
     }
   },
@@ -539,80 +539,80 @@ exports.del = {
       user: {
         notFound: {
           url: '/users/75/projects/1/pages/1/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notNumber: {
           url: '/users/cade/projects/1/pages/1/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notInteger: {
           url: '/users/3.1415/projects/1/pages/1/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         doesNotOwnProject: {
           url: '/users/1/projects/3/pages/1/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         }
       },
       project: {
         notFound: {
           url: '/users/1/projects/75/pages/1/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notNumber: {
           url: '/users/1/projects/foo/pages/1/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notInteger: {
           url: '/users/1/projects/3.1415/pages/1/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         pageNotInProject: {
           url: '/users/1/projects/1/pages/7/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         }
       },
       page: {
         notFound: {
           url: '/users/1/projects/1/pages/78/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notNumber: {
           url: '/users/1/projects/1/pages/foo/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notInteger: {
           url: '/users/1/projects/1/pages/3.1415/elements/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         }
       },
       element: {
         notFound: {
           url: '/users/1/projects/1/pages/1/elements/43',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notNumber: {
           url: '/users/1/projects/1/pages/1/elements/foo',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         },
         notInteger: {
           url: '/users/1/projects/1/pages/1/elements/1.5',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { styles: {} }
         }
@@ -621,13 +621,13 @@ exports.del = {
     auth: {
       notOwner: {
         url: '/users/2/projects/3/pages/7/elements/10',
-        method: 'delete',
+        method: 'DELETE',
         headers: userToken
       }
     },
     error: {
       url: '/users/1/projects/1/pages/1/elements/1',
-      method: 'delete',
+      method: 'DELETE',
       headers: userToken
     }
   }
@@ -636,6 +636,6 @@ exports.del = {
 exports.options = {
   success: {
     url: '/users/1/projects/1/pages/1/elements/1',
-    method: 'options'
+    method: 'OPTIONS'
   }
 };

--- a/test/fixtures/configs/page-handlers.js
+++ b/test/fixtures/configs/page-handlers.js
@@ -13,7 +13,7 @@ var moderatorToken = {
 exports.prerequisites = {
   fail: {
     url: '/users/1/projects/1/pages/1',
-    method: 'patch',
+    method: 'PATCH',
     payload: {
       x: 4
     },
@@ -26,11 +26,11 @@ exports.get = {
     success: {
       manyPages:{
         url: '/users/1/projects/1/pages',
-        method: 'get'
+        method: 'GET'
       },
       noPages: {
         url: '/users/1/projects/2/pages',
-        method: 'get'
+        method: 'GET'
       }
     },
     fail: {
@@ -38,39 +38,39 @@ exports.get = {
         user: {
           notFound: {
             url: '/users/99/projects/3/pages',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/cade/projects/1/pages',
-            method: 'get'
+            method: 'GET'
           },
           notInteger: {
             url: '/users/1.5/projects/1/pages',
-            method: 'get'
+            method: 'GET'
           },
           doesNotOwnProject: {
             url: '/users/1/projects/4/pages',
-            method: 'get'
+            method: 'GET'
           }
         },
         project: {
           notFound: {
             url: '/users/1/projects/89/pages',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects/coolproject/pages',
-            method: 'get'
+            method: 'GET'
           },
           notInteger: {
             url: '/users/1/projects/1.5/pages',
-            method: 'get'
+            method: 'GET'
           }
         }
       },
       error: {
         url: '/users/1/projects/1/pages',
-        method: 'get'
+        method: 'GET'
       }
     }
   },
@@ -78,11 +78,11 @@ exports.get = {
     success: {
       pageWithElements: {
         url: '/users/1/projects/1/pages/1',
-        method: 'get'
+        method: 'GET'
       },
       pageWithoutElements: {
         url: '/users/1/projects/1/pages/2',
-        method: 'get'
+        method: 'GET'
       }
     },
     fail: {
@@ -90,57 +90,57 @@ exports.get = {
         user: {
           notFound: {
             url: '/users/99/projects/3/pages/1',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/cade/projects/1/pages/1',
-            method: 'get'
+            method: 'GET'
           },
           notInteger: {
             url: '/users/1.5/projects/1/pages/1',
-            method: 'get'
+            method: 'GET'
           },
           doesNotOwnProject: {
             url: '/users/1/projects/4/pages/1',
-            method: 'get'
+            method: 'GET'
           }
         },
         project: {
           notFound: {
             url: '/users/1/projects/89/pages/1',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects/coolproject/pages/1',
-            method: 'get'
+            method: 'GET'
           },
           notInteger: {
             url: '/users/1/projects/1.5/pages/1',
-            method: 'get'
+            method: 'GET'
           },
           pageNotInProject: {
             url: '/users/1/projects/1/pages/8',
-            method: 'get'
+            method: 'GET'
           }
         },
         page: {
           notFound: {
             url: '/users/1/projects/1/pages/9001',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects/1/pages/applesauce',
-            method: 'get'
+            method: 'GET'
           },
           notInteger: {
             url: '/users/1/projects/1/pages/1.5',
-            method: 'get'
+            method: 'GET'
           }
         }
       },
       error: {
         url: '/users/1/projects/1/pages/1',
-        method: 'get'
+        method: 'GET'
       }
     }
   }
@@ -150,7 +150,7 @@ exports.create = {
   success: {
     emptyStyles: {
       url: '/users/1/projects/2/pages',
-      method: 'post',
+      method: 'POST',
       headers: userToken,
       payload: {
         x: 0,
@@ -159,7 +159,7 @@ exports.create = {
     },
     withStyle: {
       url: '/users/1/projects/2/pages',
-      method: 'post',
+      method: 'POST',
       headers: userToken,
       payload: {
         x: 0,
@@ -171,7 +171,7 @@ exports.create = {
     },
     negativeXY: {
       url: '/users/1/projects/2/pages',
-      method: 'post',
+      method: 'POST',
       headers: userToken,
       payload: {
         x: -1,
@@ -184,7 +184,7 @@ exports.create = {
       user: {
         notFound: {
           url: '/users/99/projects/3/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 5,
@@ -193,7 +193,7 @@ exports.create = {
         },
         notNumber: {
           url: '/users/cade/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 5,
@@ -202,7 +202,7 @@ exports.create = {
         },
         notInteger: {
           url: '/users/1.5/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 5,
@@ -211,7 +211,7 @@ exports.create = {
         },
         doesNotOwnProject: {
           url: '/users/1/projects/4/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 5,
@@ -222,7 +222,7 @@ exports.create = {
       project: {
         notFound: {
           url: '/users/1/projects/89/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 5,
@@ -231,7 +231,7 @@ exports.create = {
         },
         notNumber: {
           url: '/users/1/projects/coolproject/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 5,
@@ -240,7 +240,7 @@ exports.create = {
         },
         notInteger: {
           url: '/users/1/projects/1.5/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 5,
@@ -253,7 +253,7 @@ exports.create = {
       x: {
         notProvided: {
           url: '/users/1/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             y: 1
@@ -261,7 +261,7 @@ exports.create = {
         },
         notNumber: {
           url: '/users/1/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 'foo',
@@ -270,7 +270,7 @@ exports.create = {
         },
         notInteger: {
           url: '/users/1/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 1.5,
@@ -281,7 +281,7 @@ exports.create = {
       y: {
         notProvided: {
           url: '/users/1/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 1
@@ -289,7 +289,7 @@ exports.create = {
         },
         notNumber: {
           url: '/users/1/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 1,
@@ -298,7 +298,7 @@ exports.create = {
         },
         notInteger: {
           url: '/users/1/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 1,
@@ -309,7 +309,7 @@ exports.create = {
       xy: {
         duplicateCoords: {
           url: '/users/1/projects/2/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x:0,
@@ -320,7 +320,7 @@ exports.create = {
       styles: {
         notObject: {
           url: '/users/1/projects/1/pages',
-          method: 'post',
+          method: 'POST',
           headers: userToken,
           payload: {
             x: 1,
@@ -333,7 +333,7 @@ exports.create = {
     auth: {
       wrongUser: {
         url: '/users/1/projects/1/pages',
-        method: 'post',
+        method: 'POST',
         headers: userToken2,
         payload: {
           x: 2,
@@ -343,7 +343,7 @@ exports.create = {
     },
     error: {
       url: '/users/1/projects/1/pages',
-      method: 'post',
+      method: 'POST',
       headers: userToken,
       payload: {
         x: 3,
@@ -357,7 +357,7 @@ exports.patch = {
   success: {
     onlyX: {
       url: '/users/1/projects/1/pages/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         x: 12
@@ -365,7 +365,7 @@ exports.patch = {
     },
     onlyY: {
       url: '/users/1/projects/1/pages/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         y: 12
@@ -373,7 +373,7 @@ exports.patch = {
     },
     onlyStyles: {
       url: '/users/1/projects/1/pages/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         styles: {
@@ -383,7 +383,7 @@ exports.patch = {
     },
     all: {
       url: '/users/1/projects/1/pages/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         x: 10,
@@ -399,25 +399,25 @@ exports.patch = {
       user: {
         notFound: {
           url: '/users/75/projects/1/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         },
         notNumber: {
           url: '/users/cade/projects/1/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         },
         notInteger: {
           url: '/users/1.5/projects/1/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         },
         doesNotOwnProject: {
           url: '/users/1/projects/4/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         }
@@ -425,25 +425,25 @@ exports.patch = {
       project: {
         notFound: {
           url: '/users/1/projects/75/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         },
         notNumber: {
           url: '/users/1/projects/foo/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         },
         notInteger: {
           url: '/users/1/projects/1.5/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         },
         pageNotInProject: {
           url: '/users/1/projects/1/pages/7',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         }
@@ -451,19 +451,19 @@ exports.patch = {
       page: {
         notFound: {
           url: '/users/1/projects/1/pages/87',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         },
         notNumber: {
           url: '/users/1/projects/1/pages/foo',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         },
         notInteger: {
           url: '/users/1/projects/1/pages/1.5',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: { x: 1 }
         }
@@ -473,7 +473,7 @@ exports.patch = {
       x: {
         notNumber: {
           url: '/users/1/projects/1/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: {
             x: 'foo'
@@ -481,7 +481,7 @@ exports.patch = {
         },
         notInteger: {
           url: '/users/1/projects/1/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: {
             x: 1.5
@@ -491,7 +491,7 @@ exports.patch = {
       y: {
         notNumber: {
           url: '/users/1/projects/1/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: {
             y: 'foo'
@@ -499,7 +499,7 @@ exports.patch = {
         },
         notInteger: {
           url: '/users/1/projects/1/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: {
             y: 1.5
@@ -509,7 +509,7 @@ exports.patch = {
       xy: {
         duplicateCoords: {
           url: '/users/1/projects/1/pages/2',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: {
             x: 1,
@@ -520,7 +520,7 @@ exports.patch = {
       styles: {
         notObject: {
           url: '/users/1/projects/1/pages/1',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken,
           payload: {
             styles: 'foo'
@@ -529,14 +529,14 @@ exports.patch = {
       },
       missingAll: {
         url: '/users/1/projects/1/pages/1',
-        method: 'patch',
+        method: 'PATCH',
         headers: userToken,
         payload: {}
       }
     },
     error: {
       url: '/users/1/projects/1/pages/1',
-      method: 'patch',
+      method: 'PATCH',
       headers: userToken,
       payload: {
         x: 25
@@ -549,12 +549,12 @@ exports.del = {
   success: {
     owner: {
       url: '/users/1/projects/1/pages/1',
-      method: 'delete',
+      method: 'DELETE',
       headers: userToken
     },
     moderator: {
       url: '/users/1/projects/1/pages/2',
-      method: 'delete',
+      method: 'DELETE',
       headers: moderatorToken
     }
   },
@@ -563,61 +563,61 @@ exports.del = {
       user: {
         notFound: {
           url: '/users/75/projects/1/pages/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notNumber: {
           url: '/users/cade/projects/1/pages/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notInteger: {
           url: '/users/3.1415/projects/1/pages/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         doesNotOwnProject: {
           url: '/users/1/projects/3/pages/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         }
       },
       project: {
         notFound: {
           url: '/users/1/projects/75/pages/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notNumber: {
           url: '/users/1/projects/foo/pages/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notInteger: {
           url: '/users/1/projects/3.1415/pages/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         pageNotInProject: {
           url: '/users/1/projects/1/pages/7',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         }
       },
       page: {
         notFound: {
           url: '/users/1/projects/1/pages/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notNumber: {
           url: '/users/1/projects/1/pages/foo',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notInteger: {
           url: '/users/1/projects/1/pages/3.1415',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         }
       }
@@ -625,13 +625,13 @@ exports.del = {
     auth: {
       notOwner: {
         url: '/users/1/projects/1/pages/3',
-        method: 'delete',
+        method: 'DELETE',
         headers: userToken2
       }
     },
     error: {
       url: '/users/1/projects/1/pages/3',
-      method: 'delete',
+      method: 'DELETE',
       headers: userToken
     }
   }
@@ -640,6 +640,6 @@ exports.del = {
 exports.options = {
   success: {
     url: '/users/1/projects/1/pages/1',
-    method: 'options'
+    method: 'OPTIONS'
   }
 };

--- a/test/fixtures/configs/project-handlers.js
+++ b/test/fixtures/configs/project-handlers.js
@@ -13,14 +13,14 @@ var moderatorToken = {
 exports.pgAdapter = {
   fail: {
     url: '/discover',
-    method: 'get'
+    method: 'GET'
   }
 };
 
 exports.prerequisites = {
   fail: {
     url: '/users/1/projects/1',
-    method: 'patch',
+    method: 'PATCH',
     payload: {
       title: 'new'
     },
@@ -33,19 +33,19 @@ exports.get = {
     success: {
       default: {
         url: '/discover',
-        method: 'get'
+        method: 'GET'
       },
       changeCount: {
         url: '/discover?count=3',
-        method: 'get'
+        method: 'GET'
       },
       changePage: {
         url: '/discover?count=3&page=2',
-        method: 'get'
+        method: 'GET'
       },
       returnsNoneWhenPageTooHigh: {
         url: '/discover?count=50&page=2',
-        method: 'get'
+        method: 'GET'
       }
     },
     fail: {
@@ -53,11 +53,11 @@ exports.get = {
         count: {
           negative: {
             url: '/discover?count=-1',
-            method: 'get'
+            method: 'GET'
           },
           tooHigh: {
             url: '/discover?count=101',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/discover?count=foo'
@@ -66,11 +66,11 @@ exports.get = {
         page: {
           negative: {
             url: '/discover?page=-1',
-            method: 'get'
+            method: 'GET'
           },
           tooHigh: {
             url: '/discover?page=51',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/discover?page=foo'
@@ -79,41 +79,41 @@ exports.get = {
       },
       error: {
         url: '/discover',
-        method: 'get'
+        method: 'GET'
       }
     }
   },
   one: {
     success: {
       url: '/users/1/projects/1',
-      method: 'get'
+      method: 'GET'
     },
     fail: {
       params: {
         user: {
           notFound: {
             url: '/users/90/projects/1',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/foo/projects/1',
-            method: 'get'
+            method: 'GET'
           }
         },
         projects: {
           notFound: {
             url: '/users/1/projects/4',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects/foo',
-            method: 'get'
+            method: 'GET'
           }
         }
       },
       error: {
         url: '/users/1/projects/1',
-        method: 'get'
+        method: 'GET'
       }
     }
   },
@@ -121,19 +121,19 @@ exports.get = {
     success: {
       default: {
         url: '/projects',
-        method: 'get'
+        method: 'GET'
       },
       changeCount: {
         url: '/projects?count=3',
-        method: 'get'
+        method: 'GET'
       },
       changePage: {
         url: '/projects?count=3&page=2',
-        method: 'get'
+        method: 'GET'
       },
       returnsNoneWhenPageTooHigh: {
         url: '/projects?count=50&page=2',
-        method: 'get'
+        method: 'GET'
       }
     },
     fail: {
@@ -141,11 +141,11 @@ exports.get = {
         count: {
           negative: {
             url: '/projects?count=-1',
-            method: 'get'
+            method: 'GET'
           },
           tooHigh: {
             url: '/projects?count=101',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/projects?count=foo'
@@ -154,11 +154,11 @@ exports.get = {
         page: {
           negative: {
             url: '/projects?page=-1',
-            method: 'get'
+            method: 'GET'
           },
           tooHigh: {
             url: '/projects?page=51',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/projects?page=foo'
@@ -167,7 +167,7 @@ exports.get = {
       },
       error: {
         url: '/projects',
-        method: 'get'
+        method: 'GET'
       }
     }
   },
@@ -175,19 +175,19 @@ exports.get = {
     success: {
       default: {
         url: '/users/1/projects',
-        method: 'get'
+        method: 'GET'
       },
       changeCount: {
         url: '/users/1/projects?count=3',
-        method: 'get'
+        method: 'GET'
       },
       changePage: {
         url: '/users/1/projects?count=2&page=2',
-        method: 'get'
+        method: 'GET'
       },
       returnsNoneWhenPageTooHigh: {
         url: '/users/1/projects?count=50&page=2',
-        method: 'get'
+        method: 'GET'
       }
     },
     fail: {
@@ -195,11 +195,11 @@ exports.get = {
         count: {
           negative: {
             url: '/users/1/projects?count=-1',
-            method: 'get'
+            method: 'GET'
           },
           tooHigh: {
             url: '/users/1/projects?count=101',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects?count=foo'
@@ -208,11 +208,11 @@ exports.get = {
         page: {
           negative: {
             url: '/users/1/projects?page=-1',
-            method: 'get'
+            method: 'GET'
           },
           tooHigh: {
             url: '/users/1/projects?page=51',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects?page=foo'
@@ -223,17 +223,17 @@ exports.get = {
         user: {
           notFound: {
             url: '/users/90/projects',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/foo/projects',
-            method: 'get'
+            method: 'GET'
           }
         }
       },
       error: {
         url: '/users/1/projects',
-        method: 'get'
+        method: 'GET'
       }
     }
   },
@@ -241,19 +241,19 @@ exports.get = {
     success: {
       default: {
         url: '/users/1/projects/1/remixes',
-        method: 'get'
+        method: 'GET'
       },
       changeCount: {
         url: '/users/1/projects/1/remixes?count=3',
-        method: 'get'
+        method: 'GET'
       },
       changePage: {
         url: '/users/1/projects/1/remixes?count=2&page=2',
-        method: 'get'
+        method: 'GET'
       },
       returnsNoneWhenPageTooHigh: {
         url: '/users/1/projects/1/remixes?count=50&page=2',
-        method: 'get'
+        method: 'GET'
       }
     },
     fail: {
@@ -261,11 +261,11 @@ exports.get = {
         count: {
           negative: {
             url: '/users/1/projects/1/remixes?count=-1',
-            method: 'get'
+            method: 'GET'
           },
           tooHigh: {
             url: '/users/1/projects/1/remixes?count=101',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects/1/remixes?count=foo'
@@ -274,11 +274,11 @@ exports.get = {
         page: {
           negative: {
             url: '/users/1/projects/1/remixes?page=-1',
-            method: 'get'
+            method: 'GET'
           },
           tooHigh: {
             url: '/users/1/projects/1/remixes?page=900',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/1/projects/1/remixes?page=foo'
@@ -289,17 +289,17 @@ exports.get = {
         user: {
           notFound: {
             url: '/users/90/projects/1/remixes',
-            method: 'get'
+            method: 'GET'
           },
           notNumber: {
             url: '/users/foo/projects/1/remixes',
-            method: 'get'
+            method: 'GET'
           }
         }
       },
       error: {
         url: '/users/1/projects/1/remixes',
-        method: 'get'
+        method: 'GET'
       }
     }
   }
@@ -310,7 +310,7 @@ exports.create = {
     success: {
       withoutThumbnail: {
         url: '/users/1/projects',
-        method: 'post',
+        method: 'POST',
         payload: {
           title: 'create_test'
         },
@@ -318,7 +318,7 @@ exports.create = {
       },
       withThumbnail: {
         url: '/users/1/projects',
-        method: 'post',
+        method: 'POST',
         payload: {
           title: 'create_test2',
           thumbnail: {
@@ -332,7 +332,7 @@ exports.create = {
       payload: {
         title: {
           url: '/users/1/projects',
-          method: 'post',
+          method: 'POST',
           payload: {
             title: 123,
             thumbnail: {
@@ -343,7 +343,7 @@ exports.create = {
         },
         thumb: {
           url: '/users/1/projects',
-          method: 'post',
+          method: 'POST',
           payload: {
             title: 'bad_thumb',
             thumbnail: 'https://example.com/image.png'
@@ -352,7 +352,7 @@ exports.create = {
         },
         thumbValue: {
           url: '/users/1/projects',
-          method: 'post',
+          method: 'POST',
           payload: {
             title: 'bad_thumb',
             thumbnail: {
@@ -363,7 +363,7 @@ exports.create = {
         },
         thumbKey: {
           url: '/users/1/projects',
-          method: 'post',
+          method: 'POST',
           payload: {
             title: 'bad_thumb',
             thumbnail: {
@@ -377,7 +377,7 @@ exports.create = {
         user: {
           notNumber : {
             url: '/users/foo/projects',
-            method: 'post',
+            method: 'POST',
             payload: {
               title: 'bad_param',
               thumbnail: {
@@ -388,7 +388,7 @@ exports.create = {
           },
           notFound : {
             url: '/users/56/projects',
-            method: 'post',
+            method: 'POST',
             payload: {
               title: 'bad_param',
               thumbnail: {
@@ -402,7 +402,7 @@ exports.create = {
       auth: {
         wrongUser: {
           url: '/users/1/projects',
-          method: 'post',
+          method: 'POST',
           payload: {
             title: 'bad_param',
             thumbnail: {
@@ -414,7 +414,7 @@ exports.create = {
       },
       error: {
         url: '/users/1/projects',
-        method: 'post',
+        method: 'POST',
         payload: {
           title: 'error_test'
         },
@@ -426,12 +426,12 @@ exports.create = {
     success: {
       remix:{
         url: '/users/1/projects/2/remixes',
-        method: 'post',
+        method: 'POST',
         headers: userToken
       },
       checkRemix: {
         url: '/users/1/projects/$1',
-        method: 'get'
+        method: 'GET'
       }
     },
     fail: {
@@ -439,31 +439,31 @@ exports.create = {
         user: {
           notNumber: {
             url: '/users/foo/projects/2/remixes',
-            method: 'post',
+            method: 'POST',
             headers: userToken
           },
           notFound: {
             url: '/users/45/projects/2/remixes',
-            method: 'post',
+            method: 'POST',
             headers: userToken
           }
         },
         project: {
           notNumber: {
             url: '/users/1/projects/foo/remixes',
-            method: 'post',
+            method: 'POST',
             headers: userToken
           },
           notFound: {
             url: '/users/1/projects/2334/remixes',
-            method: 'post',
+            method: 'POST',
             headers: userToken
           }
         }
       },
       error: {
         url: '/users/1/projects/2/remixes',
-        method: 'post',
+        method: 'POST',
         headers: userToken
       }
     }
@@ -475,7 +475,7 @@ exports.patch = {
     success: {
       title: {
         url: '/users/1/projects/1',
-        method: 'patch',
+        method: 'PATCH',
         payload: {
           title: 'new'
         },
@@ -483,7 +483,7 @@ exports.patch = {
       },
       thumb: {
         url: '/users/1/projects/1',
-        method: 'patch',
+        method: 'PATCH',
         payload: {
           thumbnail: {
             '400': 'new'
@@ -493,7 +493,7 @@ exports.patch = {
       },
       thumb2: {
         url: '/users/1/projects/1',
-        method: 'patch',
+        method: 'PATCH',
         payload: {
           thumbnail: {
             '1024': 'new'
@@ -503,7 +503,7 @@ exports.patch = {
       },
       clearThumb: {
         url: '/users/1/projects/1',
-        method: 'patch',
+        method: 'PATCH',
         payload: {
           thumbnail: {}
         },
@@ -511,7 +511,7 @@ exports.patch = {
       },
       all: {
         url: '/users/1/projects/1',
-        method: 'patch',
+        method: 'PATCH',
         payload: {
           title: 'new2',
           thumbnail: {
@@ -525,7 +525,7 @@ exports.patch = {
       param: {
         user: {
           url: '/users/cade/projects/1',
-          method: 'patch',
+          method: 'PATCH',
           payload: {
             title: 'new2'
           },
@@ -533,7 +533,7 @@ exports.patch = {
         },
         project: {
           url: '/users/1/projects/wat',
-          method: 'patch',
+          method: 'PATCH',
           payload: {
             title: 'new2'
           },
@@ -543,7 +543,7 @@ exports.patch = {
       payload: {
         title: {
           url: '/users/1/projects/1',
-          method: 'patch',
+          method: 'PATCH',
           payload: {
             title: 123
           },
@@ -551,7 +551,7 @@ exports.patch = {
         },
         thumb: {
           url: '/users/1/projects/1',
-          method: 'patch',
+          method: 'PATCH',
           payload: {
             thumbnail: 123
           },
@@ -559,7 +559,7 @@ exports.patch = {
         },
         thumbValue: {
           url: '/users/1/projects/1',
-          method: 'patch',
+          method: 'PATCH',
           payload: {
             thumbnail: {
               400: 123
@@ -569,7 +569,7 @@ exports.patch = {
         },
         thumbKey: {
           url: '/users/1/projects/1',
-          method: 'patch',
+          method: 'PATCH',
           payload: {
             thumbnail: {
               2048: 'new'
@@ -581,7 +581,7 @@ exports.patch = {
       auth: {
         wrongUser: {
           url: '/users/1/projects/1',
-          method: 'patch',
+          method: 'PATCH',
           payload: {
             thumbnail: {
               400: 'new'
@@ -592,7 +592,7 @@ exports.patch = {
       },
       error:  {
         url: '/users/1/projects/1',
-        method: 'patch',
+        method: 'PATCH',
         payload: {
           title: 'new'
         },
@@ -604,12 +604,12 @@ exports.patch = {
     success: {
       feature: {
         url: '/users/1/projects/1/feature',
-        method: 'patch',
+        method: 'PATCH',
         headers: moderatorToken
       },
       unfeature: {
         url: '/users/1/projects/2/feature',
-        method: 'patch',
+        method: 'PATCH',
         headers: moderatorToken
       }
     },
@@ -618,24 +618,24 @@ exports.patch = {
         user: {
           notFound: {
             url: '/users/90/projects/1/feature',
-            method: 'patch',
+            method: 'PATCH',
             headers: moderatorToken
           },
           notNumber: {
             url: '/users/foo/projects/1/feature',
-            method: 'patch',
+            method: 'PATCH',
             headers: moderatorToken
           }
         },
         project: {
           notFound: {
             url: '/users/1/projects/90/feature',
-            method: 'patch',
+            method: 'PATCH',
             headers: moderatorToken
           },
           notNumber: {
             url: '/users/1/projects/foo/feature',
-            method: 'patch',
+            method: 'PATCH',
             headers: moderatorToken
           }
         }
@@ -643,13 +643,13 @@ exports.patch = {
       auth: {
         notMod: {
           url: '/users/1/projects/1/feature',
-          method: 'patch',
+          method: 'PATCH',
           headers: userToken
         }
       },
       error: {
         url: '/users/1/projects/1/feature',
-        method: 'patch',
+        method: 'PATCH',
         headers: moderatorToken
       }
     }
@@ -660,12 +660,12 @@ exports.del = {
   success: {
     owner:{
       url: '/users/1/projects/1',
-      method: 'delete',
+      method: 'DELETE',
       headers: userToken
     },
     moderator: {
       url: '/users/1/projects/2',
-      method: 'delete',
+      method: 'DELETE',
       headers: moderatorToken
     }
   },
@@ -674,24 +674,24 @@ exports.del = {
       user: {
         notNumber: {
           url: '/users/foo/projects/2',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notFound: {
           url: '/users/45/projects/2',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         }
       },
       project: {
         notNumber: {
           url: '/users/1/projects/foo',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         },
         notFound: {
           url: '/users/1/projects/1',
-          method: 'delete',
+          method: 'DELETE',
           headers: userToken
         }
       }
@@ -699,13 +699,13 @@ exports.del = {
     auth: {
       notOwner: {
         url: '/users/3/projects/5',
-        method: 'delete',
+        method: 'DELETE',
         headers: userToken2
       }
     },
     error: {
       url: '/users/2/projects/3',
-      method: 'delete',
+      method: 'DELETE',
       headers: userToken2
     }
   }
@@ -714,6 +714,6 @@ exports.del = {
 exports.options = {
   success: {
     url: '/discover',
-    method: 'options'
+    method: 'OPTIONS'
   }
 };

--- a/test/fixtures/configs/user-handlers.js
+++ b/test/fixtures/configs/user-handlers.js
@@ -1,7 +1,7 @@
 exports.create = {
   success: {
     url: '/users',
-    method: 'post',
+    method: 'POST',
     payload: {
       username: 'newuser',
       language: 'en',
@@ -10,7 +10,7 @@ exports.create = {
   },
   duplicateUsername: {
     url: '/users',
-    method: 'post',
+    method: 'POST',
     payload: {
       username: 'newuser',
       language: 'en',
@@ -19,7 +19,7 @@ exports.create = {
   },
   noLang: {
     url: '/users',
-    method: 'post',
+    method: 'POST',
     payload: {
       username: 'newuser2',
       country: 'CA'
@@ -27,7 +27,7 @@ exports.create = {
   },
   noCountry: {
     url: '/users',
-    method: 'post',
+    method: 'POST',
     payload: {
       username: 'newuser3',
       language: 'en'
@@ -38,21 +38,21 @@ exports.create = {
 exports.get = {
   success: {
     url: '/users/1',
-    method: 'get',
+    method: 'GET',
     headers: {
       authorization: 'token userToken'
     }
   },
   invalidId: {
     url: '/users/90',
-    method: 'get',
+    method: 'GET',
     headers: {
       authorization: 'token userToken'
     }
   },
   notYourAccount: {
     url: '/users/2',
-    method: 'get',
+    method: 'GET',
     headers: {
       authorization: 'token userToken'
     }
@@ -62,7 +62,7 @@ exports.get = {
 exports.patch = {
   updateEverything: {
     url: '/users/1',
-    method: 'patch',
+    method: 'PATCH',
     headers: {
       authorization: 'token userToken'
     },
@@ -74,7 +74,7 @@ exports.patch = {
   },
   username: {
     url: '/users/1',
-    method: 'patch',
+    method: 'PATCH',
     headers: {
       authorization: 'token userToken'
     },
@@ -84,7 +84,7 @@ exports.patch = {
   },
   language: {
     url: '/users/1',
-    method: 'patch',
+    method: 'PATCH',
     headers: {
       authorization: 'token userToken'
     },
@@ -94,7 +94,7 @@ exports.patch = {
   },
   userNotFound: {
     url: '/users/90',
-    method: 'patch',
+    method: 'PATCH',
     headers: {
       authorization: 'token userToken'
     },
@@ -106,7 +106,7 @@ exports.patch = {
   },
   unauthorized: {
     url: '/users/2',
-    method: 'patch',
+    method: 'PATCH',
     headers: {
       authorization: 'token userToken'
     },
@@ -118,7 +118,7 @@ exports.patch = {
   },
   duplicateUsername: {
     url: '/users/2',
-    method: 'patch',
+    method: 'PATCH',
     headers: {
       authorization: 'token userToken2'
     },
@@ -131,34 +131,34 @@ exports.patch = {
 exports.del = {
   success: {
     url: '/users/1',
-    method: 'delete',
+    method: 'DELETE',
     headers: {
       authorization: 'token userToken'
     }
   },
   userNotFound: {
     url: '/users/90',
-    method: 'delete',
+    method: 'DELETE',
     headers: {
       authorization: 'token userToken'
     }
   },
   unauthorized: {
     url: '/users/3',
-    method: 'delete',
+    method: 'DELETE',
     headers: {
       authorization: 'token userToken2'
     }
   },
   fail: {
     url: '/users/2',
-    method: 'delete',
+    method: 'DELETE',
     headers: {
       authorization: 'token userToken2'
     }
   }, fail2: {
     url: '/users/3',
-    method: 'delete',
+    method: 'DELETE',
     headers: {
       authorization: 'token moderatorToken'
     }
@@ -168,7 +168,7 @@ exports.del = {
 exports.options = {
   success: {
     url: '/users/1',
-    method: 'options',
+    method: 'OPTIONS',
     headers: {
       authorization: 'token userToken'
     }

--- a/test/services/api/handlers/docs.js
+++ b/test/services/api/handlers/docs.js
@@ -23,7 +23,7 @@ experiment('Docs', function() {
     test('GET / redirects to /docs', function(done) {
       var opts = {
         url: '/',
-        method: 'get'
+        method: 'GET'
       };
 
       server.inject(opts, function(resp) {

--- a/test/services/api/handlers/elements.js
+++ b/test/services/api/handlers/elements.js
@@ -1054,7 +1054,7 @@ experiment('Element Handlers', function() {
     });
   });
 
-  experiment('options', function() {
+  experiment('OPTIONS', function() {
     test('responds to options requests', function(done) {
       var opts = configs.options.success;
 

--- a/test/services/api/handlers/pages.js
+++ b/test/services/api/handlers/pages.js
@@ -1077,7 +1077,7 @@ experiment('Page Handlers', function() {
     });
   });
 
-  experiment('options', function() {
+  experiment('OPTIONS', function() {
     test('responds to options requests', function(done) {
       var opts = configs.options.success;
 

--- a/test/services/api/routes/elements.js
+++ b/test/services/api/routes/elements.js
@@ -10,12 +10,12 @@ experiment('Element routes', function() {
   test(
     'applies config to get /users/{user}/projects/{project}/pages/{page}/elements',
     function(done) {
-      var pages = routes.at('get /users/{user}/projects/{project}/pages/{page}/elements');
+      var pages = routes.at('GET /users/{user}/projects/{project}/pages/{page}/elements');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('get');
+      expect(pages.method).to.equal('GET');
       expect(pages.config.auth).to.be.false();
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'post', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -30,12 +30,12 @@ experiment('Element routes', function() {
   test(
     'applies config to get /users/{user}/projects/{project}/pages/{page}/elements/{element}',
     function(done) {
-      var pages = routes.at('get /users/{user}/projects/{project}/pages/{page}/elements/{element}');
+      var pages = routes.at('GET /users/{user}/projects/{project}/pages/{page}/elements/{element}');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('get');
+      expect(pages.method).to.equal('GET');
       expect(pages.config.auth).to.be.false();
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -51,15 +51,15 @@ experiment('Element routes', function() {
   test(
     'applies config to post /users/{user}/projects/{project}/pages/{page}/elements',
     function(done) {
-      var pages = routes.at('post /users/{user}/projects/{project}/pages/{page}/elements');
+      var pages = routes.at('POST /users/{user}/projects/{project}/pages/{page}/elements');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('post');
+      expect(pages.method).to.equal('POST');
       expect(pages.config.auth).to.be.an.object();
       expect(pages.config.auth.mode).to.equal('required');
       expect(pages.config.auth.strategies).to.include('token');
       expect(pages.config.auth.scope).to.equal('projects');
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'post', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -78,15 +78,15 @@ experiment('Element routes', function() {
   test(
     'applies config to patch /users/{user}/projects/{project}/pages/{page}/elements/{element}',
     function(done) {
-      var pages = routes.at('patch /users/{user}/projects/{project}/pages/{page}/elements/{element}');
+      var pages = routes.at('PATCH /users/{user}/projects/{project}/pages/{page}/elements/{element}');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('patch');
+      expect(pages.method).to.equal('PATCH');
       expect(pages.config.auth).to.be.an.object();
       expect(pages.config.auth.mode).to.equal('required');
       expect(pages.config.auth.strategies).to.include('token');
       expect(pages.config.auth.scope).to.equal('projects');
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -103,15 +103,15 @@ experiment('Element routes', function() {
   test(
     'applies config to delete /users/{user}/projects/{project}/pages/{page}/elements/{element}',
     function(done) {
-      var pages = routes.at('delete /users/{user}/projects/{project}/pages/{page}/elements/{element}');
+      var pages = routes.at('DELETE /users/{user}/projects/{project}/pages/{page}/elements/{element}');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('delete');
+      expect(pages.method).to.equal('DELETE');
       expect(pages.config.auth).to.be.an.object();
       expect(pages.config.auth.mode).to.equal('required');
       expect(pages.config.auth.strategies).to.include('token');
       expect(pages.config.auth.scope).to.equal('projects');
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -127,12 +127,12 @@ experiment('Element routes', function() {
   test(
     'applies config to options /users/{user}/projects/{project}/pages/{page}/elements',
     function(done) {
-      var pages = routes.at('options /users/{user}/projects/{project}/pages/{page}/elements');
+      var pages = routes.at('OPTIONS /users/{user}/projects/{project}/pages/{page}/elements');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('options');
+      expect(pages.method).to.equal('OPTIONS');
       expect(pages.config.auth).to.be.false();
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'post', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -145,12 +145,12 @@ experiment('Element routes', function() {
   test(
     'applies config to options /users/{user}/projects/{project}/pages/{page}/elements/{element}',
     function(done) {
-      var pages = routes.at('options /users/{user}/projects/{project}/pages/{page}/elements/{element}');
+      var pages = routes.at('OPTIONS /users/{user}/projects/{project}/pages/{page}/elements/{element}');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('options');
+      expect(pages.method).to.equal('OPTIONS');
       expect(pages.config.auth).to.be.false();
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();

--- a/test/services/api/routes/pages.js
+++ b/test/services/api/routes/pages.js
@@ -10,12 +10,12 @@ experiment('pages routes', function() {
   test(
     'applies config to get /users/{user}/projects/{project}/pages',
     function(done) {
-      var pages = routes.at('get /users/{user}/projects/{project}/pages');
+      var pages = routes.at('GET /users/{user}/projects/{project}/pages');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('get');
+      expect(pages.method).to.equal('GET');
       expect(pages.config.auth).to.be.false();
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'post', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -29,12 +29,12 @@ experiment('pages routes', function() {
   test(
     'applies config to get /users/{user}/projects/{project}/pages/{page}',
     function(done) {
-      var pages = routes.at('get /users/{user}/projects/{project}/pages/{page}');
+      var pages = routes.at('GET /users/{user}/projects/{project}/pages/{page}');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('get');
+      expect(pages.method).to.equal('GET');
       expect(pages.config.auth).to.be.false();
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -49,15 +49,15 @@ experiment('pages routes', function() {
   test(
     'applies config to post /users/{user}/projects/{project}/pages',
     function(done) {
-      var pages = routes.at('post /users/{user}/projects/{project}/pages');
+      var pages = routes.at('POST /users/{user}/projects/{project}/pages');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('post');
+      expect(pages.method).to.equal('POST');
       expect(pages.config.auth).to.be.an.object();
       expect(pages.config.auth.mode).to.equal('required');
       expect(pages.config.auth.strategies).to.include('token');
       expect(pages.config.auth.scope).to.equal('projects');
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'post', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -75,15 +75,15 @@ experiment('pages routes', function() {
   test(
     'applies config to patch /users/{user}/projects/{project}/pages/{page}',
     function(done) {
-      var pages = routes.at('patch /users/{user}/projects/{project}/pages/{page}');
+      var pages = routes.at('PATCH /users/{user}/projects/{project}/pages/{page}');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('patch');
+      expect(pages.method).to.equal('PATCH');
       expect(pages.config.auth).to.be.an.object();
       expect(pages.config.auth.mode).to.equal('required');
       expect(pages.config.auth.strategies).to.include('token');
       expect(pages.config.auth.scope).to.equal('projects');
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -99,15 +99,15 @@ experiment('pages routes', function() {
   test(
     'applies config to delete /users/{user}/projects/{project}/pages/{page}',
     function(done) {
-      var pages = routes.at('delete /users/{user}/projects/{project}/pages/{page}');
+      var pages = routes.at('DELETE /users/{user}/projects/{project}/pages/{page}');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('delete');
+      expect(pages.method).to.equal('DELETE');
       expect(pages.config.auth).to.be.an.object();
       expect(pages.config.auth.mode).to.equal('required');
       expect(pages.config.auth.strategies).to.include('token');
       expect(pages.config.auth.scope).to.equal('projects');
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -122,12 +122,12 @@ experiment('pages routes', function() {
   test(
     'applies config to options /users/{user}/projects/{project}/pages',
     function(done) {
-      var pages = routes.at('options /users/{user}/projects/{project}/pages');
+      var pages = routes.at('OPTIONS /users/{user}/projects/{project}/pages');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('options');
+      expect(pages.method).to.equal('OPTIONS');
       expect(pages.config.auth).to.be.false();
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'post', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();
@@ -139,12 +139,12 @@ experiment('pages routes', function() {
   test(
     'applies config to options /users/{user}/projects/{project}/pages/{page}',
     function(done) {
-      var pages = routes.at('options /users/{user}/projects/{project}/pages/{page}');
+      var pages = routes.at('OPTIONS /users/{user}/projects/{project}/pages/{page}');
       expect(pages).to.be.an.object();
-      expect(pages.method).to.equal('options');
+      expect(pages.method).to.equal('OPTIONS');
       expect(pages.config.auth).to.be.false();
       expect(pages.config.cors).to.be.an.object();
-      expect(pages.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+      expect(pages.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
       expect(pages.config.validate).to.be.an.object();
       expect(pages.config.validate.params).to.be.an.object();
       expect(pages.config.validate.params.user).to.be.an.object();

--- a/test/services/api/routes/projects.js
+++ b/test/services/api/routes/projects.js
@@ -7,12 +7,12 @@ var Lab = require('lab'),
 
 experiment('project routes', function() {
   test('applies config to get /discover', function(done) {
-    var discover = routes.at('get /discover');
+    var discover = routes.at('GET /discover');
     expect(discover).to.be.an.object();
-    expect(discover.method).to.equal('get');
+    expect(discover.method).to.equal('GET');
     expect(discover.config.auth).to.be.false();
     expect(discover.config.cors).to.be.an.object();
-    expect(discover.config.cors.methods).to.include(['get', 'options']);
+    expect(discover.config.cors.methods).to.include(['GET', 'OPTIONS']);
     expect(discover.config.validate).to.be.an.object();
     expect(discover.config.validate.query).to.be.an.object();
     expect(discover.config.validate.query.count).to.be.an.object();
@@ -21,12 +21,12 @@ experiment('project routes', function() {
   });
 
   test('applies config to get /projects', function(done) {
-    var projects = routes.at('get /projects');
+    var projects = routes.at('GET /projects');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('get');
+    expect(projects.method).to.equal('GET');
     expect(projects.config.auth).to.be.false();
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.query).to.be.an.object();
     expect(projects.config.validate.query.count).to.be.an.object();
@@ -37,12 +37,12 @@ experiment('project routes', function() {
   });
 
   test('applies config to get /users/{user}/projects', function(done) {
-    var projects = routes.at('get /users/{user}/projects');
+    var projects = routes.at('GET /users/{user}/projects');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('get');
+    expect(projects.method).to.equal('GET');
     expect(projects.config.auth).to.be.false();
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'post', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.params.user).to.be.an.object();
@@ -55,12 +55,12 @@ experiment('project routes', function() {
   });
 
   test('applies config to get /users/{user}/projects/{project}', function(done) {
-    var projects = routes.at('get /users/{user}/projects/{project}');
+    var projects = routes.at('GET /users/{user}/projects/{project}');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('get');
+    expect(projects.method).to.equal('GET');
     expect(projects.config.auth).to.be.false();
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'patch', 'options', 'delete']);
+    expect(projects.config.cors.methods).to.include(['GET', 'PATCH', 'OPTIONS', 'DELETE']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.params.user).to.be.an.object();
@@ -71,12 +71,12 @@ experiment('project routes', function() {
   });
 
   test('applies config to get /users/{user}/projects/{project}/remixes', function(done) {
-    var projects = routes.at('get /users/{user}/projects/{project}/remixes');
+    var projects = routes.at('GET /users/{user}/projects/{project}/remixes');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('get');
+    expect(projects.method).to.equal('GET');
     expect(projects.config.auth).to.be.false();
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'post', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.params.user).to.be.an.object();
@@ -90,15 +90,15 @@ experiment('project routes', function() {
   });
 
   test('applies config to post /users/{user}/projects', function(done) {
-    var projects = routes.at('post /users/{user}/projects');
+    var projects = routes.at('POST /users/{user}/projects');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('post');
+    expect(projects.method).to.equal('POST');
     expect(projects.config.auth).to.be.an.object();
     expect(projects.config.auth.mode).to.equal('required');
     expect(projects.config.auth.strategies).to.include('token');
     expect(projects.config.auth.scope).to.equal('projects');
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'post', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.payload).to.be.an.object();
     expect(projects.config.validate.payload.title).to.be.an.object();
@@ -110,15 +110,15 @@ experiment('project routes', function() {
   });
 
   test('applies config to patch /users/{user}/projects/{project}', function(done) {
-    var projects = routes.at('patch /users/{user}/projects/{project}');
+    var projects = routes.at('PATCH /users/{user}/projects/{project}');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('patch');
+    expect(projects.method).to.equal('PATCH');
     expect(projects.config.auth).to.be.an.object();
     expect(projects.config.auth.mode).to.equal('required');
     expect(projects.config.auth.strategies).to.include('token');
     expect(projects.config.auth.scope).to.equal('projects');
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.payload).to.be.an.object();
@@ -132,15 +132,15 @@ experiment('project routes', function() {
   });
 
   test('applies config to delete /users/{user}/projects/{project}', function(done) {
-    var projects = routes.at('delete /users/{user}/projects/{project}');
+    var projects = routes.at('DELETE /users/{user}/projects/{project}');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('delete');
+    expect(projects.method).to.equal('DELETE');
     expect(projects.config.auth).to.be.an.object();
     expect(projects.config.auth.mode).to.equal('required');
     expect(projects.config.auth.strategies).to.include('token');
     expect(projects.config.auth.scope).to.equal('projects');
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.params.project).to.be.an.object();
@@ -151,15 +151,15 @@ experiment('project routes', function() {
   });
 
   test('applies config to post /users/{user}/projects/{project}/remixes', function(done) {
-    var projects = routes.at('post /users/{user}/projects/{project}/remixes');
+    var projects = routes.at('POST /users/{user}/projects/{project}/remixes');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('post');
+    expect(projects.method).to.equal('POST');
     expect(projects.config.auth).to.be.an.object();
     expect(projects.config.auth.mode).to.equal('required');
     expect(projects.config.auth.strategies).to.include('token');
     expect(projects.config.auth.scope).to.equal('projects');
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'post', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.params.project).to.be.an.object();
@@ -170,15 +170,15 @@ experiment('project routes', function() {
   });
 
   test('applies config to patch /users/{user}/projects/{project}/feature', function(done) {
-    var projects = routes.at('patch /users/{user}/projects/{project}/feature');
+    var projects = routes.at('PATCH /users/{user}/projects/{project}/feature');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('patch');
+    expect(projects.method).to.equal('PATCH');
     expect(projects.config.auth).to.be.an.object();
     expect(projects.config.auth.mode).to.equal('required');
     expect(projects.config.auth.strategies).to.include('token');
     expect(projects.config.auth.scope).to.equal('projects');
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['post', 'options']);
+    expect(projects.config.cors.methods).to.include(['POST', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.params.project).to.be.an.object();
@@ -189,15 +189,15 @@ experiment('project routes', function() {
   });
 
   test('applies config to options /users/{user}/projects/{project}/feature', function(done) {
-    var projects = routes.at('options /users/{user}/projects/{project}/feature');
+    var projects = routes.at('OPTIONS /users/{user}/projects/{project}/feature');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('options');
+    expect(projects.method).to.equal('OPTIONS');
     expect(projects.config.auth).to.be.an.object();
     expect(projects.config.auth.mode).to.equal('required');
     expect(projects.config.auth.strategies).to.include('token');
     expect(projects.config.auth.scope).to.equal('projects');
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['post', 'options']);
+    expect(projects.config.cors.methods).to.include(['POST', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.params.project).to.be.an.object();
@@ -206,42 +206,42 @@ experiment('project routes', function() {
   });
 
   test('applies config to options /discover', function(done) {
-    var projects = routes.at('options /discover');
+    var projects = routes.at('OPTIONS /discover');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('options');
+    expect(projects.method).to.equal('OPTIONS');
     expect(projects.config.auth).to.be.false();
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'OPTIONS']);
     done();
   });
 
   test('applies config to options /projects', function(done) {
-    var projects = routes.at('options /projects');
+    var projects = routes.at('OPTIONS /projects');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('options');
+    expect(projects.method).to.equal('OPTIONS');
     expect(projects.config.auth).to.be.false();
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'OPTIONS']);
     done();
   });
 
   test('applies config to options /users/{user}/projects/{project}', function(done) {
-    var projects = routes.at('options /users/{user}/projects/{project}');
+    var projects = routes.at('OPTIONS /users/{user}/projects/{project}');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('options');
+    expect(projects.method).to.equal('OPTIONS');
     expect(projects.config.auth).to.be.false();
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'patch', 'delete', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'PATCH', 'DELETE', 'OPTIONS']);
     done();
   });
 
   test('applies config to options /users/{user}/projects/{project}/remixes', function(done) {
-    var projects = routes.at('options /users/{user}/projects/{project}/remixes');
+    var projects = routes.at('OPTIONS /users/{user}/projects/{project}/remixes');
     expect(projects).to.be.an.object();
-    expect(projects.method).to.equal('options');
+    expect(projects.method).to.equal('OPTIONS');
     expect(projects.config.auth).to.be.false();
     expect(projects.config.cors).to.be.an.object();
-    expect(projects.config.cors.methods).to.include(['get', 'post', 'options']);
+    expect(projects.config.cors.methods).to.include(['GET', 'POST', 'OPTIONS']);
     expect(projects.config.validate).to.be.an.object();
     expect(projects.config.validate.params).to.be.an.object();
     expect(projects.config.validate.params.project).to.be.an.object();

--- a/test/services/api/routes/users.js
+++ b/test/services/api/routes/users.js
@@ -7,12 +7,12 @@ var Lab = require('lab'),
 
 experiment('users routes', function() {
   test('applies config to post /users', function(done) {
-    var create = routes.at('post /users');
+    var create = routes.at('POST /users');
     expect(create).to.be.an.object();
-    expect(create.method).to.equal('post');
+    expect(create.method).to.equal('POST');
     expect(create.config.auth).to.be.false();
     expect(create.config.cors).to.be.an.object();
-    expect(create.config.cors.methods).to.include(['post', 'options']);
+    expect(create.config.cors.methods).to.include(['POST', 'OPTIONS']);
     expect(create.config.validate).to.be.an.object();
     expect(create.config.validate.payload).to.be.an.object();
     expect(create.config.validate.payload.username).to.be.an.object();
@@ -22,19 +22,19 @@ experiment('users routes', function() {
   });
 
   test('applies config to options /users', function(done) {
-    var create = routes.at('options /users');
+    var create = routes.at('OPTIONS /users');
     expect(create).to.be.an.object();
-    expect(create.method).to.equal('options');
+    expect(create.method).to.equal('OPTIONS');
     expect(create.config.auth).to.be.false();
     expect(create.config.cors).to.be.an.object();
-    expect(create.config.cors.methods).to.include(['post', 'options']);
+    expect(create.config.cors.methods).to.include(['POST', 'OPTIONS']);
     done();
   });
 
   test('applies config to docs/css/style.css', function(done) {
-    var docStyle = routes.at('get /docs/css/style.css');
+    var docStyle = routes.at('GET /docs/css/style.css');
     expect(docStyle).to.be.an.object();
-    expect(docStyle.method).to.equal('get');
+    expect(docStyle.method).to.equal('GET');
     expect(docStyle.config.auth).to.be.false();
     expect(docStyle.config.cors).to.be.false();
     expect(docStyle.config.plugins.lout).to.be.false();
@@ -44,9 +44,9 @@ experiment('users routes', function() {
   });
 
   test('applies config to /', function(done) {
-    var root = routes.at('get /');
+    var root = routes.at('GET /');
     expect(root).to.be.an.object();
-    expect(root.method).to.equal('get');
+    expect(root.method).to.equal('GET');
     expect(root.handler).to.be.a.function();
     expect(root.config.cors).to.be.false();
     expect(root.config.plugins.lout).to.be.false();
@@ -54,9 +54,9 @@ experiment('users routes', function() {
   });
 
   test('applies config to get /users/{user}', function(done) {
-    var users = routes.at('get /users/{user}');
+    var users = routes.at('GET /users/{user}');
     expect(users).to.be.an.object();
-    expect(users.method).to.equal('get');
+    expect(users.method).to.equal('GET');
     expect(users.config.auth).to.be.an.object();
     expect(users.config.auth.mode).to.equal('required');
     expect(users.config.auth.strategies).to.include('token');
@@ -65,14 +65,14 @@ experiment('users routes', function() {
     expect(users.config.validate.params).to.be.an.object();
     expect(users.config.validate.params.user).to.be.an.object();
     expect(users.config.cors).to.be.an.object();
-    expect(users.config.cors.methods).to.include(['options', 'get', 'patch', 'delete']);
+    expect(users.config.cors.methods).to.include(['OPTIONS', 'GET', 'PATCH', 'DELETE']);
     done();
   });
 
   test('applies config to delete /users/{user}', function(done) {
-    var users = routes.at('delete /users/{user}');
+    var users = routes.at('DELETE /users/{user}');
     expect(users).to.be.an.object();
-    expect(users.method).to.equal('delete');
+    expect(users.method).to.equal('DELETE');
     expect(users.config.auth).to.be.an.object();
     expect(users.config.auth.mode).to.equal('required');
     expect(users.config.auth.strategies).to.include('token');
@@ -81,27 +81,27 @@ experiment('users routes', function() {
     expect(users.config.validate.params).to.be.an.object();
     expect(users.config.validate.params.user).to.be.an.object();
     expect(users.config.cors).to.be.an.object();
-    expect(users.config.cors.methods).to.include(['options', 'get', 'patch', 'delete']);
+    expect(users.config.cors.methods).to.include(['OPTIONS', 'GET', 'PATCH', 'DELETE']);
     done();
   });
 
   test('applies config to options /users/{user}', function(done) {
-    var users = routes.at('options /users/{user}');
+    var users = routes.at('OPTIONS /users/{user}');
     expect(users).to.be.an.object();
-    expect(users.method).to.equal('options');
+    expect(users.method).to.equal('OPTIONS');
     expect(users.config.auth).to.be.an.object();
     expect(users.config.auth.mode).to.equal('required');
     expect(users.config.auth.strategies).to.include('token');
     expect(users.config.auth.scope).to.equal('user');
     expect(users.config.cors).to.be.an.object();
-    expect(users.config.cors.methods).to.include(['options', 'get', 'patch', 'delete']);
+    expect(users.config.cors.methods).to.include(['OPTIONS', 'GET', 'PATCH', 'DELETE']);
     done();
   });
 
   test('applies config to patch /users/{user}', function(done) {
-    var users = routes.at('patch /users/{user}');
+    var users = routes.at('PATCH /users/{user}');
     expect(users).to.be.an.object();
-    expect(users.method).to.equal('patch');
+    expect(users.method).to.equal('PATCH');
     expect(users.config.auth).to.be.an.object();
     expect(users.config.auth.mode).to.equal('required');
     expect(users.config.auth.strategies).to.include('token');
@@ -114,7 +114,7 @@ experiment('users routes', function() {
     expect(users.config.validate.payload.language).to.be.an.object();
     expect(users.config.validate.payload.country).to.be.an.object();
     expect(users.config.cors).to.be.an.object();
-    expect(users.config.cors.methods).to.include(['options', 'get', 'patch', 'delete']);
+    expect(users.config.cors.methods).to.include(['OPTIONS', 'GET', 'PATCH', 'DELETE']);
     done();
   });
 });


### PR DESCRIPTION
Because HTTP headers are case sensitive, the current implementation is failing for `DELETE`. Let's use uppercase since that's standard