### PR TITLE
Eliminate race condition 

### DIFF
--- a/services/api/handlers/projects.js
+++ b/services/api/handlers/projects.js
@@ -150,20 +150,9 @@ exports.get = {
 
 exports.patch = {
   update: function(request, reply) {
-    var project = request.pre.project;
-
-    if ( request.payload.title ) {
-      project.title = request.payload.title;
-    }
-
-    project.thumbnail = {
-      320: request.payload.thumbnail[320] || ''
-    };
-
     request.server.methods.projects.update(
       [
-        project.title,
-        project.thumbnail,
+        request.payload.title,
         request.params.project
       ],
       function(err, result) {

--- a/services/api/lib/queries.js
+++ b/services/api/lib/queries.js
@@ -99,9 +99,9 @@ module.exports = {
       " projects.deleted_at IS NULL AND pages.deleted_at IS NULL AND elements.deleted_at IS NULL",
 
     // Update project
-    // Params title varchar, thumbnail jsonb, project_id bigint
-    update: "UPDATE projects SET (title, thumbnail) = ($1, $2) WHERE deleted_at IS NULL" +
-      " AND id = $3 RETURNING id, user_id, remixed_from, version, title, featured," +
+    // Params title varchar, project_id bigint
+    update: "UPDATE projects SET (title) = ($1) WHERE deleted_at IS NULL" +
+      " AND id = $2 RETURNING id, user_id, remixed_from, version, title, featured," +
       " created_at, updated_at, thumbnail;",
 
     // Update project thumbnail

--- a/services/api/routes/authenticated.js
+++ b/services/api/routes/authenticated.js
@@ -169,10 +169,7 @@ var routes = [
           project: numericSchema
         },
         payload: {
-          title: Joi.string().optional(),
-          thumbnail: Joi.object().keys({
-            320: Joi.string().optional()
-          }).default({})
+          title: Joi.string().required()
         }
       },
       pre: [

--- a/services/api/routes/authenticated.js
+++ b/services/api/routes/authenticated.js
@@ -169,7 +169,8 @@ var routes = [
           project: numericSchema
         },
         payload: {
-          title: Joi.string().required()
+          title: Joi.string().required(),
+          thumbnail: Joi.object().optional()
         }
       },
       pre: [

--- a/test/fixtures/configs/project-handlers.js
+++ b/test/fixtures/configs/project-handlers.js
@@ -538,6 +538,17 @@ exports.patch = {
           title: 'new'
         },
         headers: userToken
+      },
+      withThumnailKey: {
+        url: '/users/1/projects/1',
+        method: 'patch',
+        payload: {
+          title: 'newww',
+          thumbnail: {
+            '320': 'will not work'
+          }
+        },
+        headers: userToken
       }
     },
     fail: {

--- a/test/fixtures/configs/project-handlers.js
+++ b/test/fixtures/configs/project-handlers.js
@@ -538,45 +538,6 @@ exports.patch = {
           title: 'new'
         },
         headers: userToken
-      },
-      thumb: {
-        url: '/users/1/projects/1',
-        method: 'patch',
-        payload: {
-          thumbnail: {
-            '320': 'new'
-          }
-        },
-        headers: userToken
-      },
-      thumb2: {
-        url: '/users/1/projects/1',
-        method: 'patch',
-        payload: {
-          thumbnail: {
-            '320': 'new'
-          }
-        },
-        headers: userToken
-      },
-      clearThumb: {
-        url: '/users/1/projects/1',
-        method: 'patch',
-        payload: {
-          thumbnail: {}
-        },
-        headers: userToken
-      },
-      all: {
-        url: '/users/1/projects/1',
-        method: 'patch',
-        payload: {
-          title: 'new2',
-          thumbnail: {
-            '320': 'new2'
-          }
-        },
-        headers: userToken
       }
     },
     fail: {
@@ -641,9 +602,7 @@ exports.patch = {
           url: '/users/1/projects/1',
           method: 'patch',
           payload: {
-            thumbnail: {
-              320: 'new'
-            }
+            title: 'bad form, peter'
           },
           headers: userToken2
         }
@@ -785,6 +744,28 @@ exports.tail = {
       payload: {
         x: 0
       }
+    },
+    check: {
+      url: '/users/1/projects/1',
+      method: 'get'
+    }
+  },
+  noOverwrite: {
+    update: {
+      url: '/users/1/projects/1/pages/3',
+      method: 'patch',
+      headers: userToken,
+      payload: {
+        x: 5
+      }
+    },
+    updateTitle: {
+      url: '/users/1/projects/1',
+      method: 'patch',
+      payload: {
+        title: 'foo'
+      },
+      headers: userToken
     },
     check: {
       url: '/users/1/projects/1',

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -1135,6 +1135,18 @@ experiment('Project Handlers', function() {
       });
     });
 
+    test('update with a thumbnail object succeeds, does not update thumbnail', function(done) {
+      var opts = configs.patch.update.success.withThumnailKey;
+
+      server.inject(opts, function(resp) {
+        expect(resp.statusCode).to.equal(200);
+        expect(resp.result.status).to.equal('updated');
+        expect(resp.result.project.title).to.equal('newww');
+        expect(resp.result.project.thumbnail[320]).to.not.equal('will not work');
+        done();
+      });
+    });
+
     test('invalid user param', function(done) {
       var opts = configs.patch.update.fail.param.user;
 

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -1135,29 +1135,6 @@ experiment('Project Handlers', function() {
       });
     });
 
-    test('update thumbnail (320) succeeds', function(done) {
-      var opts = configs.patch.update.success.thumb;
-
-      server.inject(opts, function(resp) {
-        expect(resp.statusCode).to.equal(200);
-        expect(resp.result.status).to.equal('updated');
-        expect(resp.result.project.thumbnail[320]).to.equal('new');
-        done();
-      });
-    });
-
-    test('update thumbnail (clearing it) succeeds', function(done) {
-      var opts = configs.patch.update.success.clearThumb;
-
-      server.inject(opts, function(resp) {
-        expect(resp.statusCode).to.equal(200);
-        expect(resp.result.status).to.equal('updated');
-        expect(resp.result.project.thumbnail).to.exist();
-        expect(resp.result.project.thumbnail[320]).to.equal('');
-        done();
-      });
-    });
-
     test('invalid user param', function(done) {
       var opts = configs.patch.update.fail.param.user;
 
@@ -1182,39 +1159,6 @@ experiment('Project Handlers', function() {
 
     test('invalid title type', function(done) {
       var opts = configs.patch.update.fail.payload.title;
-
-      server.inject(opts, function(resp) {
-        expect(resp.statusCode).to.equal(400);
-        expect(resp.result.error).to.equal('Bad Request');
-        expect(resp.result.message).to.be.a.string();
-        done();
-      });
-    });
-
-    test('invalid thumbnail type', function(done) {
-      var opts = configs.patch.update.fail.payload.thumb;
-
-      server.inject(opts, function(resp) {
-        expect(resp.statusCode).to.equal(400);
-        expect(resp.result.error).to.equal('Bad Request');
-        expect(resp.result.message).to.be.a.string();
-        done();
-      });
-    });
-
-    test('invalid thumbnail value type', function(done) {
-      var opts = configs.patch.update.fail.payload.thumbValue;
-
-      server.inject(opts, function(resp) {
-        expect(resp.statusCode).to.equal(400);
-        expect(resp.result.error).to.equal('Bad Request');
-        expect(resp.result.message).to.be.a.string();
-        done();
-      });
-    });
-
-    test('invalid thumbnail key', function(done) {
-      var opts = configs.patch.update.fail.payload.thumbKey;
 
       server.inject(opts, function(resp) {
         expect(resp.statusCode).to.equal(400);
@@ -1462,6 +1406,7 @@ experiment('Project Handlers', function() {
     var screenshotMock;
     var screenshotVal1 = 'https://example.com/screenshot1.png';
     var screenshotVal2 = 'https://example.com/screenshot2.png';
+    var screenshotVal3 = 'https://example.com/screenshot3.png';
 
     before(function(done) {
       // filteringPath used because of the time-dependent base64 string generated from the page render url
@@ -1487,6 +1432,14 @@ experiment('Project Handlers', function() {
           '/screenshotURL'
         )
         .once()
+        .reply(200, {
+          screenshot: screenshotVal3
+        })
+        .filteringPath(/^\/mobile-center-cropped\/small\/webmaker-desktop\/(.+)$/, '/screenshotURL')
+        .post(
+          '/screenshotURL'
+        )
+        .once()
         .replyWithError('horrible network destroying monster of an error')
         .filteringPath(/^\/mobile-center-cropped\/small\/webmaker-desktop\/(.+)$/, '/screenshotURL')
         .post(
@@ -1500,7 +1453,7 @@ experiment('Project Handlers', function() {
         )
         .once()
         .reply(200, {
-          screenshot: screenshotVal2
+          screenshot: screenshotVal3
         });
       done();
     });
@@ -1527,6 +1480,27 @@ experiment('Project Handlers', function() {
       });
     });
 
+    test('Project update does not overwrite thumbnail', function(done) {
+      var update = configs.tail.noOverwrite.update;
+      var check = configs.tail.noOverwrite.check;
+      var updateTitle = configs.tail.noOverwrite.updateTitle;
+
+      server.once('tail', function() {
+        server.inject(updateTitle, function(resp) {
+          expect(resp.statusCode).to.equal(200);
+          server.inject(check, function(resp) {
+            expect(resp.statusCode).to.equal(200);
+            expect(resp.result.project.thumbnail[320]).to.equal(screenshotVal2);
+            done();
+          });
+        });
+      });
+
+      server.inject(update, function(resp) {
+        expect(resp.statusCode).to.equal(200);
+      });
+    });
+
     test('updating (not) the lowest page id in a project does not trigger a screenshot update', function(done) {
       var update = configs.tail.noUpdate.update;
       var check = configs.tail.noUpdate.check;
@@ -1535,7 +1509,7 @@ experiment('Project Handlers', function() {
         server.inject(check, function(resp) {
           expect(resp.statusCode).to.equal(200);
           // should not be different from previous test
-          expect(resp.result.project.thumbnail[320]).to.equal(screenshotVal1);
+          expect(resp.result.project.thumbnail[320]).to.equal(screenshotVal2);
           done();
         });
       });
@@ -1552,7 +1526,7 @@ experiment('Project Handlers', function() {
       server.once('tail', function() {
         server.inject(check, function(resp) {
           expect(resp.statusCode).to.equal(200);
-          expect(resp.result.project.thumbnail[320]).to.equal(screenshotVal2);
+          expect(resp.result.project.thumbnail[320]).to.equal(screenshotVal3);
           done();
         });
       });
@@ -1572,7 +1546,7 @@ experiment('Project Handlers', function() {
           server.inject(check, function(resp) {
             expect(resp.statusCode).to.equal(200);
             // should not be different from previous test
-            expect(resp.result.project.thumbnail[320]).to.equal(screenshotVal2);
+            expect(resp.result.project.thumbnail[320]).to.equal(screenshotVal3);
             done();
           });
         });

--- a/test/services/api/routes/projects.js
+++ b/test/services/api/routes/projects.js
@@ -125,7 +125,6 @@ experiment('project routes', function() {
     expect(projects.config.validate.params.project).to.be.an.object();
     expect(projects.config.validate.params.user).to.be.an.object();
     expect(projects.config.validate.payload.title).to.be.an.object();
-    expect(projects.config.validate.payload.thumbnail).to.be.an.object();
     expect(projects.config.pre).to.be.an.array();
     expect(projects.config.pre.length).to.equal(4);
     done();


### PR DESCRIPTION
... where a project update occurring after a thumbnail tail would erase a project thumbnail URL

Fixes mozilla/webmaker-desktop#123