### PR TITLE
Add Bassmaster for batching requests

### DIFF
--- a/adapters/plugins.js
+++ b/adapters/plugins.js
@@ -6,5 +6,11 @@ module.exports = [
   },
   require('lout'),
   require('hapi-auth-bearer-token'),
-  require('hapi-version')
+  require('hapi-version'),
+  {
+    register: require('bassmaster'),
+    options: {
+      batchEndpoint: '/batch'
+    }
+  }
 ];

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/mozilla/api.webmaker.org"
   },
   "dependencies": {
+    "bassmaster": "^1.7.0",
     "blankie": "^1.1.0",
     "boom": "^2.7.1",
     "bunyan": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/mozilla/api.webmaker.org"
   },
   "dependencies": {
-    "bassmaster": "^1.7.0",
+    "bassmaster": "^1.8.0",
     "blankie": "^1.1.0",
     "boom": "^2.7.1",
     "bunyan": "^1.3.5",

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -1128,7 +1128,6 @@ experiment('Project Handlers', function() {
           .callsArgWith(1, mockErr());
 
         server.inject(opts, function(resp) {
-          console.log( resp.result, resp.statusCode );
           expect(resp.statusCode).to.equal(500);
           expect(resp.result.error).to.equal('Internal Server Error');
           expect(resp.result.message).to.equal('An internal server error occurred');


### PR DESCRIPTION
Fixes #76 

I still need to add unit tests, but preliminary testing using httpie shows this is pretty solid.

```
 http -j post :2015/batch requests:='[{"method": "post", "path": "/users/1/projects", "payload": {"title": "project 1"} }, {"method": "post", "path": "/users/1/projects", "payload": {"title": "project 2"} } ]' authorization:'token asdlkfjasdlfkjasdflkjalsdkjf'
```