### PR TITLE
mocked authentication based on MOCKED_AUTH env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ For default installations, this will have username `postgres`, with the password
 
 See the guide for [configuring New Relic using environment variables](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/configuring-nodejs-environment-variables) to configure the New Relic agent
 
+## Optional Configuration
+
+Variable                    | Description
+----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------
+MOCKED_AUTH                 | If used the server will bypass token validation. The header "Authorization:token <token>" is still required, but will always succeed
+
 ## Test
 
 The tests require access to a postgreSQL database named `webmaker_testing`. Create it by running the command `createdb webmaker_testing`, the test script will automatically create tables and populate them with data.

--- a/lib/mockValidator.js
+++ b/lib/mockValidator.js
@@ -1,0 +1,6 @@
+module.exports = function mockValidator(token, callback) {
+  callback(null, 200, {
+    scope: ['projects'],
+    id: 1
+  });
+};

--- a/server.js
+++ b/server.js
@@ -63,10 +63,14 @@ server.register(require('./adapters/plugins'), function(err) {
     throw err;
   }
 
+  var authConfig = require('./lib/auth-config');
+  var tokenValidator = process.env.MOCKED_AUTH ?
+    require('./lib/mockValidator') : require('./lib/tokenValidator');
+
   server.auth.strategy(
     'token',
     'bearer-access-token',
-    require('./lib/auth-config')(require('./lib/tokenValidator'))
+    authConfig(tokenValidator)
   );
 });
 


### PR DESCRIPTION
adds auth mocking so that api.wmo can be used without having to depend on an id.wmo instance or oauth2 token negotiation.