### PR TITLE
Fix promises, Round 2

### DIFF
--- a/services/api/lib/postgre.js
+++ b/services/api/lib/postgre.js
@@ -144,7 +144,6 @@ module.exports = function (pg) {
         var project;
         var page;
         var transaction;
-        var transactionErr;
 
         getTransactionClient().then(function(t) {
           transaction = t;
@@ -168,13 +167,16 @@ module.exports = function (pg) {
             project: project,
             page: page
           });
-        })
-        .catch(function(err) {
-          transactionErr = err;
-          return rollback(transaction);
-        }).then(function() {
-          done(transactionErr);
         }).catch(function(err) {
+          if ( transaction ) {
+            return rollback(transaction)
+              .then(function() {
+                done(err);
+              }).catch(function(rollbackErr) {
+                done(rollbackErr);
+              });
+          }
+
           done(err);
         });
       }, {});
@@ -184,7 +186,7 @@ module.exports = function (pg) {
         var remixedElements;
         var remixedPages;
         var transaction;
-        var transactionErr;
+
         getTransactionClient().then(function(t) {
           transaction = t;
           return begin(transaction);
@@ -286,11 +288,14 @@ module.exports = function (pg) {
         }).then(function() {
           done(null, remixedProject);
         }).catch(function(err) {
-          transactionErr = err;
-          return rollback(transaction);
-        }).then(function() {
-          done(transactionErr);
-        }).catch(function(err) {
+          if ( transaction ) {
+            return rollback(transaction)
+              .then(function() {
+                done(err);
+              }).catch(function(rollbackErr) {
+                done(rollbackErr);
+              });
+          }
           done(err);
         });
       });

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -1083,6 +1083,11 @@ experiment('Project Handlers', function() {
     });
 
     experiment('Remix', function() {
+      before(function(done) {
+        // clear remix data cache
+        server.methods.cache.invalidateKey('projects', 'findDataForRemix', [1], done);
+      });
+
       test('success', function(done) {
         var opts = configs.create.remix.success.remix;
         var checkRemixProject = configs.create.remix.success.checkRemixProject;
@@ -1220,7 +1225,6 @@ experiment('Project Handlers', function() {
           .callsArgWith(1, mockErr());
 
         server.inject(opts, function(resp) {
-          console.log( resp.result, resp.statusCode );
           expect(resp.statusCode).to.equal(500);
           expect(resp.result.error).to.equal('Internal Server Error');
           expect(resp.result.message).to.equal('An internal server error occurred');

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -173,7 +173,6 @@ experiment('Project Handlers', function() {
       });
     });
 
-
     test('remix transaction error', function(done) {
       var opts = configs.pgAdapter.remixFail;
 
@@ -187,6 +186,89 @@ experiment('Project Handlers', function() {
         .returns({});
 
       sinon.stub(server.plugins['webmaker-postgre-adapter'].pg, 'connect')
+        .callsArgWith(1, mockErr());
+
+      server.inject(opts, function(resp) {
+        server.plugins['webmaker-postgre-adapter'].pg.connect.restore();
+        server.methods.users.find.restore();
+        server.methods.projects.findDataForRemix.restore();
+        server.methods.utils.formatRemixData.restore();
+        expect(resp.statusCode).to.equal(500);
+        expect(resp.result.error).to.equal('Internal Server Error');
+        expect(resp.result.message).to.equal('An internal server error occurred');
+        done();
+      });
+    });
+
+    test('Handles error from pg when creating a transaction (remixing)', function(done) {
+      var opts = configs.pgAdapter.remixFail;
+
+      sinon.stub(server.methods.users, 'find')
+        .callsArgWith(1, null, { rows: [ userFixtures.chris_testing ] });
+
+      sinon.stub(server.methods.projects, 'findDataForRemix')
+        .callsArgWith(1, null, { rows: [ {} ] });
+
+      sinon.stub(server.methods.utils, 'formatRemixData')
+        .returns({});
+
+      sinon.stub(server.plugins['webmaker-postgre-adapter'].pg, 'connect')
+        .callsArgWith(1, mockErr());
+
+      server.inject(opts, function(resp) {
+        server.plugins['webmaker-postgre-adapter'].pg.connect.restore();
+        server.methods.users.find.restore();
+        server.methods.projects.findDataForRemix.restore();
+        server.methods.utils.formatRemixData.restore();
+        expect(resp.statusCode).to.equal(500);
+        expect(resp.result.error).to.equal('Internal Server Error');
+        expect(resp.result.message).to.equal('An internal server error occurred');
+        done();
+      });
+    });
+
+    test('Handles error from pg after rolling back a transaction (remixing)', function(done) {
+      var opts = configs.pgAdapter.remixFail;
+      var clientStub = {
+        query: sinon.stub()
+      };
+
+      clientStub.query.onFirstCall()
+        .onFirstCall().callsArgWith(1, userFixtures.chris_testing)
+        .onSecondCall().callsArgWith(1, null, { rows: [ {} ] })
+        .onThirdCall().callsArgWith(1, null, { rows: [{ id: '1' }] })
+        .onCall(3).callsArgWith(1, null, { rows: [{ id: '1' }] })
+        .onCall(4).callsArgWith(1, mockErr())
+        .onCall(5).callsArgWith(1, null, {});
+
+      sinon.stub(server.plugins['webmaker-postgre-adapter'].pg, 'connect')
+        .callsArgWith(1, null, clientStub, function() {});
+
+      server.inject(opts, function(resp) {
+        server.plugins['webmaker-postgre-adapter'].pg.connect.restore();
+        expect(resp.statusCode).to.equal(500);
+        expect(resp.result.error).to.equal('Internal Server Error');
+        expect(resp.result.message).to.equal('An internal server error occurred');
+        done();
+      });
+    });
+
+    test('Handles error if rollback fails (remixing)', function(done) {
+      var opts = configs.pgAdapter.remixFail;
+
+      sinon.stub(server.methods.users, 'find')
+        .callsArgWith(1, null, { rows: [ userFixtures.chris_testing ] });
+
+      sinon.stub(server.methods.projects, 'findDataForRemix')
+        .callsArgWith(1, null, { rows: [ {} ] });
+
+      sinon.stub(server.methods.utils, 'formatRemixData')
+        .returns({});
+
+      sinon.stub(server.plugins['webmaker-postgre-adapter'].pg, 'connect')
+        .onFirstCall()
+        .callsArgWith(1, null, {})
+        .onSecondCall()
         .callsArgWith(1, mockErr());
 
       server.inject(opts, function(resp) {


### PR DESCRIPTION
This is the same as #108, (reverted in #128) but includes a commit that fixes a failure caused by the remix data method caching a mocked data response.