### PR TITLE
force type identity on isOwner arguments

### DIFF
--- a/services/api/lib/prerequisites.js
+++ b/services/api/lib/prerequisites.js
@@ -7,7 +7,6 @@ function isOwner(tokenId, userId, projectId) {
   return (tokenId === userId && userId === projectId);
 }
 
-
 exports.calculateOffset = {
   assign: 'offset',
   method: function(request, reply) {

--- a/services/api/lib/prerequisites.js
+++ b/services/api/lib/prerequisites.js
@@ -1,9 +1,12 @@
 var boom = require('boom');
 
 function isOwner(tokenId, userId, projectId) {
-  return (tokenId === userId) &&
-    (userId === projectId);
+  tokenId = '' + tokenId;
+  userId = '' + userId;
+  projectId = '' + projectId;
+  return (tokenId === userId && userId === projectId);
 }
+
 
 exports.calculateOffset = {
   assign: 'offset',


### PR DESCRIPTION
fixes https://github.com/mozilla/api.webmaker.org/issues/130

Right now we have a situation where we might compare `1` to `'1'`, which will fail due to type inequality, even if they represent the same id. This patch fixes that by forcing all incoming data to string before evaluating.