### PR TITLE
Invalidate the page.getOne cache when updating an element

### DIFF
--- a/services/api/handlers/elements.js
+++ b/services/api/handlers/elements.js
@@ -109,6 +109,16 @@ exports.patch = {
           request.tail('drop elements.findOne cache')
         );
 
+        request.server.methods.cache.invalidateKey(
+          'pages',
+          'findOne',
+          [
+            request.params.project,
+            request.params.page
+          ],
+          request.tail('drop pages findOne cache')
+        );
+
         reply({
           status: 'updated',
           element: result.rows[0]


### PR DESCRIPTION
Fixes #134 