### PR TITLE
Generate thumbnail generation tails after a bulk transaction

### DIFF
--- a/services/api/handlers/bulk.js
+++ b/services/api/handlers/bulk.js
@@ -9,13 +9,13 @@ exports.post = function(request, reply) {
         return reply(Boom.wrap(err));
       }
 
-      request.server.methods.newrelic.createTracer(
-        'process cache invalidations',
-        request.server.methods.bulk.invalidateCaches
-      );
-      request.server.methods.bulk.invalidateCaches(request, results.map(function(result) {
+      var rawResults = results.map(function(result) {
         return result.raw;
-      }));
+      });
+
+      request.server.methods.bulk.invalidateCaches(request, rawResults);
+
+      request.server.methods.projects.processBulkThumbnailRequests(request, rawResults);
 
       reply({
         status: 'success',

--- a/services/api/handlers/elements.js
+++ b/services/api/handlers/elements.js
@@ -98,9 +98,8 @@ exports.patch = {
         }
 
         var thumbTail = request.tail('updating project thumbnail');
-        process.nextTick(function() {
-          request.server.methods.projects.checkPageId(request.pre.page, thumbTail);
-        });
+
+        request.server.methods.projects.checkPageId(request.pre.page, thumbTail);
 
         request.server.methods.cache.invalidateKey(
           'elements',

--- a/services/api/handlers/pages.js
+++ b/services/api/handlers/pages.js
@@ -118,9 +118,8 @@ exports.patch = {
 
         var page = request.server.methods.utils.formatPage(result.rows);
         var thumbTail = request.tail('updating project thumbnail');
-        process.nextTick(function() {
-          request.server.methods.projects.checkPageId(page, thumbTail);
-        });
+
+        request.server.methods.projects.checkPageId(page, thumbTail);
 
         request.server.methods.cache.invalidateKey(
           'pages',

--- a/services/api/lib/thumbnails.js
+++ b/services/api/lib/thumbnails.js
@@ -126,32 +126,23 @@ exports.register = function(server, options, done) {
         project_id: +projectId,
         page_id: + pageId
       };
-    }).reduce(function(thumbnailUpdates, result) {
-      // save the data we'll look at to some local vars
-      var newPageId = +(result.page_id || result.id);
-      var newProjectId = +result.project_id;
+    }).reduce(function(pendingUpdates, result) {
       var resultData;
-      var resultDataPageId;
 
       // iterate over existing thumbnail updates to enable some comparisons
-      for (var i = 0; i < thumbnailUpdates.length; i++) {
-        resultData = thumbnailUpdates[i];
-        resultDataPageId = +(resultData.page_id || resultData.id);
-        if (+resultData.project_id !== newProjectId) {
+      for (var i = 0; i < pendingUpdates.length; i++) {
+        resultData = pendingUpdates[i];
+        if (resultData.project_id !== result.project_id) {
           continue;
         }
-        if (newPageId < resultDataPageId) {
+        if (result.page_id < resultData.page_id) {
           break;
         }
-        return thumbnailUpdates;
+        return pendingUpdates;
       }
 
-      thumbnailUpdates.push({
-        id: result.id || result.page_id,
-        project_id: result.project_id
-      });
-
-      return thumbnailUpdates;
+      pendingUpdates.push(result);
+      return pendingUpdates;
     }, [])
     .map(function(result) {
       checkPageId(result, request.tail('updating project thumbnail'));

--- a/services/api/lib/thumbnails.js
+++ b/services/api/lib/thumbnails.js
@@ -80,8 +80,8 @@ exports.register = function(server, options, done) {
     });
   }
 
-  // Check if the given page has the lowest id in its parent project
-  // If it is, then request a new thumbnail
+  // Check if the given page has the lowest id of all pages in its parent project
+  // In most cases, this means the first page created when a project is created (situated at 0,0)
   function checkPageId(page, tail) {
     process.nextTick(function() {
       if ( !process.env.THUMBNAIL_SERVICE_URL ) {


### PR DESCRIPTION
Fixes #165 

This PR is missing three lines of test coverage. We need to craft specific test payloads so that these code paths can be executed.

cc/ @ashleygwilliams & @jbuck 