### PR TITLE
Count project views using POST /view-project/{project_id}

### DIFF
--- a/migrations/05_add_project_views.sql
+++ b/migrations/05_add_project_views.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS project_views
+(
+  project_id bigint REFERENCES projects(id),
+  view_count bigint NOT NULL DEFAULT 0
+);
+
+CREATE INDEX project_views_idx ON project_views (project_id);
+
+COMMIT;

--- a/scripts/create-tables.sql
+++ b/scripts/create-tables.sql
@@ -57,6 +57,12 @@ CREATE TABLE IF NOT EXISTS "elements"
   CONSTRAINT elements_id_pk PRIMARY KEY (id)
 );
 
+CREATE TABLE IF NOT EXISTS project_views
+(
+  project_id bigint REFERENCES projects(id),
+  view_count bigint NOT NULL DEFAULT 0
+);
+
 /* Indexes */
 CREATE UNIQUE INDEX pages_xyid_unique_idx ON pages (project_id, x, y) WHERE (deleted_at IS NULL);
 CREATE INDEX user_idx_id_deleted_at ON users (id, deleted_at);
@@ -65,6 +71,7 @@ CREATE INDEX deleted_at_remixed_from_idx on projects (deleted_at, remixed_from);
 CREATE INDEX deleted_at_featured_idx on projects (deleted_at, featured);
 CREATE INDEX project_id_deleted_at_idx ON pages (project_id, deleted_at);
 CREATE INDEX deleted_at_page_id_idx ON elements (deleted_at, page_id);
+CREATE INDEX project_views_idx ON project_views (id);
 
 /* Triggers */
 CREATE OR REPLACE FUNCTION update_updated_at()

--- a/scripts/drop-tables.sql
+++ b/scripts/drop-tables.sql
@@ -1,6 +1,7 @@
 -- drop tables to reset auto incrementing cols
 DROP TABLE IF EXISTS elements;
 DROP TABLE IF EXISTS pages;
+DROP TABLE IF EXISTS project_views;
 DROP TABLE IF EXISTS projects;
 DROP TABLE IF EXISTS users;
 

--- a/services/api/handlers/projects.js
+++ b/services/api/handlers/projects.js
@@ -53,6 +53,18 @@ exports.post = {
         });
       }
     );
+  },
+  view: function(request, reply) {
+    request.server.methods.projects.incrementViewCount(
+      [request.params.project],
+      function(err) {
+        if (err) {
+          return reply(err);
+        }
+
+        reply('ok');
+      }
+    );
   }
 };
 

--- a/services/api/lib/postgre.js
+++ b/services/api/lib/postgre.js
@@ -586,6 +586,14 @@ module.exports = function (pg) {
         }
       });
 
+      server.method('projects.incrementViewCount', function(values, done) {
+        executeQuery(queries.projects.incrementViewCount, values, done);
+      }, {});
+
+      server.method('projects.findOneById', function(values, done) {
+        executeQuery(queries.projects.findOneById, values, done);
+      }, {});
+
       server.method('projects.update', function(values, done) {
         executeQuery(queries.projects.update, values, done);
       }, {});

--- a/services/api/lib/prerequisites.js
+++ b/services/api/lib/prerequisites.js
@@ -249,3 +249,26 @@ exports.setDescription = {
     reply(request.pre.project.description);
   }
 };
+
+exports.isValidView = function(request, reply) {
+  request.server.methods.projects.findOneById(
+    [
+      request.params.project
+    ],
+    function(err, result) {
+      if ( err ) {
+        return reply(err);
+      }
+
+      if ( !result.rows.length ) {
+        return reply(boom.badRequest('Project does not exist'));
+      }
+
+      if (result.rows[0].user_id === request.auth.credentials.id) {
+        return reply(boom.badRequest('Can not count self-views'));
+      }
+
+      reply();
+    }
+  );
+};

--- a/services/api/lib/queries.js
+++ b/services/api/lib/queries.js
@@ -167,7 +167,11 @@ module.exports = {
       "     WHEN $1 THEN 1" +
       "     ELSE 2" +
       "   END, " +
-      " projects.created_at DESC LIMIT $2 OFFSET $3;"
+      " projects.created_at DESC LIMIT $2 OFFSET $3;",
+
+    incrementViewCount: "WITH upsert AS (UPDATE project_views SET view_count = view_count + 1 WHERE project_id = $1" +
+      " RETURNING *) INSERT INTO project_views (project_id, view_count) SELECT $1, 1 WHERE NOT EXISTS" +
+      " (SELECT * FROM upsert);"
   },
   pages: {
     // Create page

--- a/services/api/routes/authenticated.js
+++ b/services/api/routes/authenticated.js
@@ -566,6 +566,26 @@ var routes = [
         methods: ['GET', 'PATCH', 'DELETE', 'OPTIONS']
       }
     }
+  }, {
+    path: '/view-project/{project}',
+    method: 'post',
+    handler: projects.post.view,
+    config: {
+      auth: {
+        scope: 'projects'
+      },
+      validate: {
+        params: {
+          project: numericSchema
+        }
+      },
+      pre: [
+        prerequisites.isValidView
+      ],
+      cors: {
+        methods: ['POST', 'OPTIONS']
+      }
+    }
   }
 ];
 

--- a/services/api/routes/public.js
+++ b/services/api/routes/public.js
@@ -257,6 +257,20 @@ var routes = [
       }
     }
   }, {
+    path: '/view-project/{project}',
+    method: 'options',
+    handler: projects.options,
+    config: {
+      validate: {
+        params: {
+          project: numericSchema
+        }
+      },
+      cors: {
+        methods: ['POST', 'OPTIONS']
+      }
+    }
+  }, {
     path: '/users/{user}/projects/{project}/pages',
     method: 'get',
     handler: pages.get.all,

--- a/test/fixtures/configs/project-handlers.js
+++ b/test/fixtures/configs/project-handlers.js
@@ -999,3 +999,26 @@ exports.tail = {
     }
   }
 };
+
+exports.views = {
+  firstView: {
+    url: '/view-project/1',
+    method: 'post',
+    headers: userToken2
+  },
+  subsequentView: {
+    url: '/view-project/1',
+    method: 'post',
+    headers: userToken2
+  },
+  ownView: {
+    url: '/view-project/1',
+    method: 'post',
+    headers: userToken
+  },
+  badProject: {
+    url: '/view-project/1234',
+    method: 'post',
+    headers: userToken
+  }
+};


### PR DESCRIPTION
`POST /view-project/{project_id}`

Requires a valid Authorization header, 400s if user owns project or if project doesn't exist.

Uses an upsert query to initialize a project's view count to 1, increments it thereafter.

mozilla/webmaker-core#902