### PR TITLE
Fix patch response

### DIFF
--- a/services/api/handlers/projects.js
+++ b/services/api/handlers/projects.js
@@ -273,7 +273,7 @@ exports.patch = {
           request.params.user,
           request.tail('drop projects.findUsersProjects cache')
         );
-
+console.log(result.rows);
         reply({
           status: 'updated',
           project: request.server.methods.utils.formatProject(result.rows[0])

--- a/services/api/handlers/projects.js
+++ b/services/api/handlers/projects.js
@@ -273,7 +273,7 @@ exports.patch = {
           request.params.user,
           request.tail('drop projects.findUsersProjects cache')
         );
-console.log(result.rows);
+
         reply({
           status: 'updated',
           project: request.server.methods.utils.formatProject(result.rows[0])

--- a/services/api/lib/queries.js
+++ b/services/api/lib/queries.js
@@ -137,7 +137,7 @@ module.exports = {
     // Update project
     // Params title varchar, project_id bigint
     update: "UPDATE projects SET (title, description, metadata) = ($1, $2, $3) WHERE deleted_at IS NULL" +
-      " AND id = $4 RETURNING id, user_id, remixed_from, version, title, featured, description, metadata" +
+      " AND id = $4 RETURNING id, user_id, remixed_from, version, title, featured, description, metadata->'tags' as tags," +
       " created_at, updated_at, thumbnail;",
 
     // Update project thumbnail

--- a/services/api/lib/queries.js
+++ b/services/api/lib/queries.js
@@ -137,8 +137,8 @@ module.exports = {
     // Update project
     // Params title varchar, project_id bigint
     update: "UPDATE projects SET (title, description, metadata) = ($1, $2, $3) WHERE deleted_at IS NULL" +
-      " AND id = $4 RETURNING id, user_id, remixed_from, version, title, featured, description, metadata->'tags' as tags," +
-      " created_at, updated_at, thumbnail;",
+      " AND id = $4 RETURNING id, user_id, remixed_from, version, title, featured, description," +
+      " metadata->'tags' as tags, created_at, updated_at, thumbnail;",
 
     // Update project thumbnail
     // Params thumbnail jsonb, project_id bigint

--- a/test/fixtures/configs/project-handlers.js
+++ b/test/fixtures/configs/project-handlers.js
@@ -724,6 +724,38 @@ exports.patch = {
           description: 'this is a newww-erer description'
         },
         headers: userToken
+      },
+      updateDescriptionWithTag: {
+        url: '/users/1/projects/1',
+        method: 'patch',
+        payload: {
+          description: 'this is #tagged'
+        },
+        headers: userToken
+      },
+      canChangeTag: {
+        url: '/users/1/projects/1',
+        method: 'patch',
+        payload: {
+          description: 'this is a #different #tag'
+        },
+        headers: userToken
+      },
+      noDuplicates: {
+        url: '/users/1/projects/1',
+        method: 'patch',
+        payload: {
+          description: '#mozilla #Mozilla #MOZILLA'
+        },
+        headers: userToken
+      },
+      canClearTags: {
+        url: '/users/1/projects/1',
+        method: 'patch',
+        payload: {
+          description: 'no moar tags'
+        },
+        headers: userToken
       }
     },
     fail: {

--- a/test/fixtures/configs/project-handlers.js
+++ b/test/fixtures/configs/project-handlers.js
@@ -733,11 +733,11 @@ exports.patch = {
         },
         headers: userToken
       },
-      canChangeTag: {
+      canChangeTags: {
         url: '/users/1/projects/1',
         method: 'patch',
         payload: {
-          description: 'this is a #different #tag'
+          description: 'this has #different #tags'
         },
         headers: userToken
       },

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -1610,6 +1610,51 @@ experiment('Project Handlers', function() {
       });
     });
 
+    test('update with a tag in the description', function(done) {
+      var opts = configs.patch.update.success.updateDescriptionWithTag;
+
+      server.inject(opts, function(resp) {
+        expect(resp.statusCode).to.equal(200);
+        expect(resp.result.status).to.equal('updated');
+        expect(resp.result.tags).to.include('tagged');
+        done();
+      });
+    });
+
+    test('can change tags', function(done) {
+      var opts = configs.patch.update.success.withoutTitle;
+
+      server.inject(opts, function(resp) {
+        expect(resp.statusCode).to.equal(200);
+        expect(resp.result.status).to.equal('updated');
+        expect(resp.result.tags).to.include('different');
+        done();
+      });
+    });
+
+    test('No duplicate tags, including those of different case', function(done) {
+      var opts = configs.patch.update.success.withoutTitle;
+
+      server.inject(opts, function(resp) {
+        expect(resp.statusCode).to.equal(200);
+        expect(resp.result.status).to.equal('updated');
+        expect(resp.result.tags.length).to.equal(1);
+        expect(resp.result.tags).to.include('mozilla');
+        done();
+      });
+    });
+
+    test('tag array cleared if desc contains no hashtags', function(done) {
+      var opts = configs.patch.update.success.withoutTitle;
+
+      server.inject(opts, function(resp) {
+        expect(resp.statusCode).to.equal(200);
+        expect(resp.result.status).to.equal('updated');
+        expect(resp.result.tags.length).to.equal(0);
+        done();
+      });
+    });
+
     test('invalid user param', function(done) {
       var opts = configs.patch.update.fail.param.user;
 

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -1616,41 +1616,41 @@ experiment('Project Handlers', function() {
       server.inject(opts, function(resp) {
         expect(resp.statusCode).to.equal(200);
         expect(resp.result.status).to.equal('updated');
-        expect(resp.result.tags).to.include('tagged');
+        expect(resp.result.project.tags).to.include('tagged');
         done();
       });
     });
 
     test('can change tags', function(done) {
-      var opts = configs.patch.update.success.withoutTitle;
+      var opts = configs.patch.update.success.canChangeTags;
 
       server.inject(opts, function(resp) {
         expect(resp.statusCode).to.equal(200);
         expect(resp.result.status).to.equal('updated');
-        expect(resp.result.tags).to.include('different');
+        expect(resp.result.project.tags).to.include('different', 'tags');
         done();
       });
     });
 
     test('No duplicate tags, including those of different case', function(done) {
-      var opts = configs.patch.update.success.withoutTitle;
+      var opts = configs.patch.update.success.noDuplicates;
 
       server.inject(opts, function(resp) {
         expect(resp.statusCode).to.equal(200);
         expect(resp.result.status).to.equal('updated');
-        expect(resp.result.tags.length).to.equal(1);
-        expect(resp.result.tags).to.include('mozilla');
+        expect(resp.result.project.tags.length).to.equal(1);
+        expect(resp.result.project.tags).to.include('mozilla');
         done();
       });
     });
 
     test('tag array cleared if desc contains no hashtags', function(done) {
-      var opts = configs.patch.update.success.withoutTitle;
+      var opts = configs.patch.update.success.canClearTags;
 
       server.inject(opts, function(resp) {
         expect(resp.statusCode).to.equal(200);
         expect(resp.result.status).to.equal('updated');
-        expect(resp.result.tags.length).to.equal(0);
+        expect(resp.result.project.tags.length).to.equal(0);
         done();
       });
     });


### PR DESCRIPTION
Depends on #189 - Tests assume the case insensitive tagging fix is applied

I noticed a problem in the format of the project data returned when updating.

It was a missing comma in the query for updating, that magically didn't throw any errors! I've fixed it, and added tests to make sure description/tagging updates work going forward.