### PR TITLE
Don't include description or tags in remixed projects

### DIFF
--- a/services/api/lib/postgre.js
+++ b/services/api/lib/postgre.js
@@ -212,8 +212,8 @@ module.exports = function (pg) {
               server.methods.utils.version(),
               dataToRemix.title,
               dataToRemix.thumbnail,
-              dataToRemix.description,
-              dataToRemix.metadata
+              '',
+              { tags: [] }
             ]
           );
         }).then(function(result) {

--- a/services/api/lib/queries.js
+++ b/services/api/lib/queries.js
@@ -55,7 +55,6 @@ var remixCols = [
   "projects.id AS project_id",
   "projects.title AS project_title",
   "projects.thumbnail AS project_thumbnail",
-  "projects.description AS project_description",
   "projects.metadata AS project_metadata",
   "pages.id AS page_id",
   "pages.project_id AS project_id",

--- a/services/api/lib/utils.js
+++ b/services/api/lib/utils.js
@@ -165,7 +165,6 @@ function formatRemixData(rows) {
     id: rows[0].project_id,
     title: rows[0].project_title,
     thumbnail: rows[0].project_thumbnail,
-    description: rows[0].project_description,
     metadata: rows[0].project_metadata,
     pages: pages
   };


### PR DESCRIPTION
This patch modifies the remix route to not include description or metadata fields when remixing a project. 