### PR TITLE
Use a pre-eslint version of mofo-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jscs": "^1.11.3",
     "jshint": "^2.6.3",
     "lab": "^5.5.0",
-    "mofo-style": "latest",
+    "mofo-style": "1.1.0",
     "nock": "^2.2.0",
     "sinon": "^1.14.1"
   },


### PR DESCRIPTION
we previously requested the "latest" version of mofo-lint, but now that it's on eslint, our scripts fail.

I'd upgrade to eslint, but there are over 5800 warnings!