### PR TITLE
Allow empty description string in PATCH /users/{user}/projects/{project}

### DIFF
--- a/services/api/routes/authenticated.js
+++ b/services/api/routes/authenticated.js
@@ -286,7 +286,7 @@ var routes = [
         payload: {
           title: Joi.string().max(250).optional(),
           thumbnail: Joi.object().optional(),
-          description: Joi.string().max(140).optional()
+          description: Joi.string().max(140).allow('').optional()
         }
       },
       pre: [

--- a/test/fixtures/configs/project-handlers.js
+++ b/test/fixtures/configs/project-handlers.js
@@ -756,6 +756,14 @@ exports.patch = {
           description: 'no moar tags'
         },
         headers: userToken
+      },
+      updateEmptyDescription: {
+        url: '/users/1/projects/1',
+        method: 'patch',
+        payload: {
+          description: ''
+        },
+        headers: userToken
       }
     },
     fail: {

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -1584,6 +1584,17 @@ experiment('Project Handlers', function() {
       });
     });
 
+    test ('update empty description succeeds', function(done) {
+      var opts = configs.patch.update.success.updateEmptyDescription;
+
+      server.inject(opts, function (resp) {
+        expect(resp.statusCode).to.equal(200);
+        expect(resp.result.status).to.equal('updated');
+        expect(resp.result.project.description).to.equal('');
+        done();
+      });
+    });
+
     test('update with a thumbnail object succeeds, does not update thumbnail', function(done) {
       var opts = configs.patch.update.success.withThumbnailKey;
 

--- a/test/services/api/handlers/projects.js
+++ b/test/services/api/handlers/projects.js
@@ -1584,7 +1584,7 @@ experiment('Project Handlers', function() {
       });
     });
 
-    test ('update empty description succeeds', function(done) {
+    test('update empty description succeeds', function(done) {
       var opts = configs.patch.update.success.updateEmptyDescription;
 
       server.inject(opts, function (resp) {


### PR DESCRIPTION
![](https://media2.giphy.com/media/OYRWgc4fqv7xu/200.gif)

cc: @cadecairos @xmatthewx R+?

Closes #197, mozilla/webmaker-core#994